### PR TITLE
Disable performance test on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,14 +49,6 @@ jobs:
               | sed "s/Tests\///")
             ./.circleci/test.sh $testsToRun
 
-      - run:
-          name: Performance Test
-          command: |
-            if [ $CIRCLE_NODE_INDEX -eq 0 ]
-            then
-              ./performanceTest.wls master @HEAD 2
-            fi
-
   cpp-test:
     docker:
       - image: alpine:3.12.1


### PR DESCRIPTION
## Changes

* `./performanceTest.wls` currently fails on CI because the fix to it was not ported from *SetReplace*.
* This disables that test entirely since it is currently empty anyway.