### PR TITLE
Change phase conventions

### DIFF
--- a/Tests/PostTagSystemFinalState.wlt
+++ b/Tests/PostTagSystemFinalState.wlt
@@ -25,15 +25,15 @@
         testUnevaluated[PostTagSystemFinalState[{0, nineZeros}, #],
                         {PostTagSystemFinalState::eventCountUneven}] & /@ {1, 2, 3, 4, 5, 6, 7, 9, 100},
 
-        VerificationTest[PostTagSystemFinalState[{0, {0, 0, 0, 0, 0, 0, 0, 0, 0}}, 8], {2, {0, 0, 0, 0, 0, 0, 0}}],
-        VerificationTest[PostTagSystemFinalState[{1, {1, 1, 1, 1, 1, 1, 1, 1, 1}}, 8],
-                         {2, {1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1}}],
+        VerificationTest[PostTagSystemFinalState[{0, {0, 0, 0, 0, 0, 0, 0, 0, 0}}, 8], {1, {0, 0, 0, 0, 0, 0, 0}}],
+        VerificationTest[PostTagSystemFinalState[{2, {1, 1, 1, 1, 1, 1, 1, 1, 1}}, 8],
+                         {1, {1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1}}],
         VerificationTest[PostTagSystemFinalState[{0, {}}, 8], {0, {}}],
         VerificationTest[PostTagSystemFinalState[{0, {0}}, 8], {0, {0}}],
         VerificationTest[PostTagSystemFinalState[{0, nineZeros}, 0], {0, nineZeros}],
 
         VerificationTest[PostTagSystemFinalState[{0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, 20858040],
-                         {1, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}],
+                         {2, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}],
         VerificationTest[PostTagSystemFinalState[{0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, #],
                          {0, {0, 0, 0, 0, 0, 0, 0}}] & /@ {20858048, 20858048 + 8, 2^32 - 8, 2^63 - 8},
 

--- a/libPostTagSystem/PostTagHistory.cpp
+++ b/libPostTagSystem/PostTagHistory.cpp
@@ -24,9 +24,9 @@ class PostTagHistory::Implementation {
   static constexpr uint16_t chunkCount = 768;
   using ChunkEvaluationTable = std::array<ChunkOutput, chunkCount>;
 
-  static constexpr uint8_t outputTapes[] = {0, 0, 0, 3, 1, 0};
-  static constexpr uint8_t outputLengths[] = {1, 1, 0, 2, 1, 1};
-  static constexpr uint8_t outputPhases[] = {1, 2, 0, 2, 0, 1};
+  static constexpr uint8_t outputTapes[] = {0, 0, 0, 3, 0, 1};
+  static constexpr uint8_t outputLengths[] = {1, 0, 1, 2, 1, 1};
+  static constexpr uint8_t outputPhases[] = {2, 0, 1, 1, 2, 0};
 
   const ChunkEvaluationTable chunkEvaluationTable_;
 

--- a/libPostTagSystem/PostTagMultihistory.cpp
+++ b/libPostTagSystem/PostTagMultihistory.cpp
@@ -92,12 +92,12 @@ class PostTagMultihistory::Implementation {
     PostTagState newState;
     newState.tape.insert(newState.tape.begin(), state.tape.begin() + 1, state.tape.end());
     if (state.tape.front() == 0) {
-      newState.headState = (state.headState + 1) % 3;
-      if (state.headState != 2) {
+      newState.headState = (state.headState + 2) % 3;
+      if (state.headState != 1) {
         newState.tape.push_back(0);
       }
     } else {
-      newState.headState = (state.headState + 2) % 3;
+      newState.headState = (state.headState + 1) % 3;
       switch (state.headState) {
         case 0:
           newState.tape.push_back(1);
@@ -105,11 +105,11 @@ class PostTagMultihistory::Implementation {
           break;
 
         case 1:
-          newState.tape.push_back(1);
+          newState.tape.push_back(0);
           break;
 
         case 2:
-          newState.tape.push_back(0);
+          newState.tape.push_back(1);
           break;
 
         default:

--- a/libPostTagSystem/test/PostTagSystem_test.cpp
+++ b/libPostTagSystem/test/PostTagSystem_test.cpp
@@ -18,10 +18,10 @@ TEST(PostTagSystem, simpleEvolution) {
 
 TEST(PostTagSystem, chunkEvaluationTable) {
   PostTagHistory history;
-  ASSERT_EQ(history.evaluate({{1, 0, 1, 1, 1, 0, 1, 1, 1}, 1}, 0).tape[8], 1);
-  ASSERT_EQ(history.evaluate({{1, 0, 1, 1, 1, 0, 1, 1, 1}, 1}, 8).tape.size(), 10);
+  ASSERT_EQ(history.evaluate({{1, 0, 1, 1, 1, 0, 1, 1, 1}, 2}, 0).tape[8], 1);
+  ASSERT_EQ(history.evaluate({{1, 0, 1, 1, 1, 0, 1, 1, 1}, 2}, 8).tape.size(), 10);
   ASSERT_EQ(history.evaluate({{1, 0, 1, 1, 1, 0, 1, 1}, 0}, 0).tape.size(), 8);
-  ASSERT_EQ(history.evaluate({{1, 1, 1, 1, 1, 1, 1, 1, 0}, 1}, 8).tape.size(), 12);
+  ASSERT_EQ(history.evaluate({{1, 1, 1, 1, 1, 1, 1, 1, 0}, 2}, 8).tape.size(), 12);
   ASSERT_EQ(history.evaluate({{}, 0}, 8).tape.size(), 0);
 }
 }  // namespace PostTagSystem


### PR DESCRIPTION
## Changes

* Changes the phase conventions in Post's system so that phase `1` is now phase `2`, and phase `2` is now phase `1`.
* Changes both `PostTagSystem` and `PostTagSystemFinalState` implementations.

## Examples

* ***Warning***: phases are now different. Sorry for potential headache: phases are being changes by *Stephen Wolfram*'s request:

```wl
In[] := PostTagSystemFinalState[{0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, 20858040]
Out[] = {2, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/3)
<!-- Reviewable:end -->
