### PR TITLE
GeneratePostTagSystemHistory with event count

### DIFF
--- a/Kernel/GeneratePostTagSystemHistory.m
+++ b/Kernel/GeneratePostTagSystemHistory.m
@@ -1,0 +1,61 @@
+Package["PostTagSystem`"]
+
+PackageImport["GeneralUtilities`"]
+
+PackageExport["GeneratePostTagSystemHistory"]
+
+PackageScope["generatePostTagSystemHistory"]
+
+SetUsage @ "
+GeneratePostTagSystemHistory[{initPhase$, initTape$}, maxEventCount$] computes the evolution of the Post tag system \
+starting from a state with head initPhase$ and tape initTape$ for at most maxEventCount$ events, and returns an \
+association containing information about that evolution.
+If the system reaches a state with <= 8 tape cells before maxEventCount$ is reached, that state is returned instead.
+";
+
+SyntaxInformation[GeneratePostTagSystemHistory] = {"ArgumentsPattern" -> {init_, maxEventCount_}};
+
+declareMessage[General::invalidStateFormat, "Initial state `init` in `expr` must be a pair {phase, tape}."];
+declareMessage[General::invalidInitPhase, "Initial phase `initPhase` in `expr` must be 0, 1, or 2."];
+declareMessage[General::invalidInitTape, "Initial tape `initTape` in `expr` must be a list of 0s and 1s."];
+declareMessage[General::eventCountNotInteger, "Max event count `eventCount` in `expr` must be an integer."];
+declareMessage[General::eventCountNegative, "Max event count `eventCount` in `expr` must not be negative."];
+declareMessage[General::eventCountTooLarge, "Max event count `eventCount` in `expr` must be smaller than 2^63."];
+declareMessage[General::eventCountUneven, "Max event count `eventCount` in `expr` must be a multiple of 8."];
+declareMessage[General::invalidArgumentCount, "Expected `expected` arguments in `expr` instead of `actual`."];
+
+expr : GeneratePostTagSystemHistory[args___] := ModuleScope[
+  result = Catch[generatePostTagSystemHistory[args],
+                 _ ? FailureQ,
+                 message[GeneratePostTagSystemHistory, #, <|"expr" -> HoldForm[expr]|>] &];
+  result /; !FailureQ[result]
+];
+
+generatePostTagSystemHistory[{initHead : 0 | 1 | 2, initTape : {(0 | 1) ...}},
+                        maxEventCount_Integer ? (0 <= # < 2^63 && Mod[#, 8] == 0 &)] := ModuleScope[
+  cppOutput = cpp$evaluatePostTagSystem[initHead, initTape, maxEventCount];
+  <|"EventCount" -> First[cppOutput], "FinalState" -> Through[{#[[2]] &, #[[3 ;; ]] &}[cppOutput]]|>
+];
+
+generatePostTagSystemHistory[init : Except[{_, _}], _] := throw[Failure["invalidStateFormat", <|"init" -> init|>]];
+
+generatePostTagSystemHistory[{initHead : Except[0 | 1 | 2], _}, _] :=
+  throw[Failure["invalidInitPhase", <|"initPhase" -> initHead|>]];
+
+generatePostTagSystemHistory[{_, initTape : Except[{(0 | 1) ...}]}, _] :=
+  throw[Failure["invalidInitTape", <|"initTape" -> initTape|>]];
+
+generatePostTagSystemHistory[{_, _}, maxEventCount : Except[_Integer]] :=
+  throw[Failure["eventCountNotInteger", <|"eventCount" -> maxEventCount|>]];
+
+generatePostTagSystemHistory[{_, _}, maxEventCount_Integer ? (# < 0 &)] :=
+  throw[Failure["eventCountNegative", <|"eventCount" -> maxEventCount|>]];
+
+generatePostTagSystemHistory[{_, _}, maxEventCount_Integer ? (# >= 2^63 &)] :=
+  throw[Failure["eventCountTooLarge", <|"eventCount" -> maxEventCount|>]];
+
+generatePostTagSystemHistory[{_, _}, maxEventCount_Integer ? (0 <= # < 2^63 && Mod[#, 8] != 0 &)] :=
+  throw[Failure["eventCountUneven", <|"eventCount" -> maxEventCount|>]];
+
+generatePostTagSystemHistory[args___] :=
+  throw[Failure["invalidArgumentCount", <|"expected" -> 2, "actual" -> Length[{args}]|>]];

--- a/Kernel/PostTagSystemFinalState.m
+++ b/Kernel/PostTagSystemFinalState.m
@@ -10,17 +10,7 @@ starting from a state with head initPhase$ and tape initTape$ for at most maxEve
 If the system reaches a state with <= 8 tape cells before maxEventCount$ is reached, that state is returned instead.
 ";
 
-SyntaxInformation[PostTagSystemFinalState] = {"ArgumentsPattern" -> {init_, maxEventCount_}};
-
-declareMessage[General::invalidStateFormat, "Initial state `init` in `expr` must be a pair {phase, tape}."];
-declareMessage[General::invalidInitPhase, "Initial phase `initPhase` in `expr` must be 0, 1, or 2."];
-declareMessage[General::invalidInitTape, "Initial tape `initTape` in `expr` must be a list of 0s and 1s."];
-declareMessage[General::eventCountNotInteger, "Max event count `eventCount` in `expr` must be an integer."];
-declareMessage[General::eventCountNegative, "Max event count `eventCount` in `expr` must not be negative."];
-declareMessage[General::eventCountTooLarge, "Max event count `eventCount` in `expr` must be smaller than 2^63."];
-declareMessage[General::eventCountUneven, "Max event count `eventCount` in `expr` must be a multiple of 8."];
-declareMessage[
-  PostTagSystemFinalState::invalidArgumentCount, "Expected `expected` arguments in `expr` instead of `actual`."];
+SyntaxInformation[PostTagSystemFinalState] = SyntaxInformation[GeneratePostTagSystemHistory];
 
 expr : PostTagSystemFinalState[args___] := ModuleScope[
   result = Catch[
@@ -28,29 +18,4 @@ expr : PostTagSystemFinalState[args___] := ModuleScope[
   result /; !FailureQ[result]
 ];
 
-postTagSystemFinalState[{initHead : 0 | 1 | 2, initTape : {(0 | 1) ...}},
-                        maxEventCount_Integer ? (0 <= # < 2^63 && Mod[#, 8] == 0 &)] :=
-  Through[{#[[2]] &, #[[3 ;; ]] &}[cpp$evaluatePostTagSystem[initHead, initTape, maxEventCount]]]
-
-postTagSystemFinalState[init : Except[{_, _}], _] := throw[Failure["invalidStateFormat", <|"init" -> init|>]];
-
-postTagSystemFinalState[{initHead : Except[0 | 1 | 2], _}, _] :=
-  throw[Failure["invalidInitPhase", <|"initPhase" -> initHead|>]];
-
-postTagSystemFinalState[{_, initTape : Except[{(0 | 1) ...}]}, _] :=
-  throw[Failure["invalidInitTape", <|"initTape" -> initTape|>]];
-
-postTagSystemFinalState[{_, _}, maxEventCount : Except[_Integer]] :=
-  throw[Failure["eventCountNotInteger", <|"eventCount" -> maxEventCount|>]];
-
-postTagSystemFinalState[{_, _}, maxEventCount_Integer ? (# < 0 &)] :=
-  throw[Failure["eventCountNegative", <|"eventCount" -> maxEventCount|>]];
-
-postTagSystemFinalState[{_, _}, maxEventCount_Integer ? (# >= 2^63 &)] :=
-  throw[Failure["eventCountTooLarge", <|"eventCount" -> maxEventCount|>]];
-
-postTagSystemFinalState[{_, _}, maxEventCount_Integer ? (0 <= # < 2^63 && Mod[#, 8] != 0 &)] :=
-  throw[Failure["eventCountUneven", <|"eventCount" -> maxEventCount|>]];
-
-postTagSystemFinalState[args___] :=
-  throw[Failure["invalidArgumentCount", <|"expected" -> 2, "actual" -> Length[{args}]|>]];
+postTagSystemFinalState[args___] := generatePostTagSystemHistory[args]["FinalState"];

--- a/Kernel/PostTagSystemFinalState.m
+++ b/Kernel/PostTagSystemFinalState.m
@@ -30,7 +30,7 @@ expr : PostTagSystemFinalState[args___] := ModuleScope[
 
 postTagSystemFinalState[{initHead : 0 | 1 | 2, initTape : {(0 | 1) ...}},
                         maxEventCount_Integer ? (0 <= # < 2^63 && Mod[#, 8] == 0 &)] :=
-  Through[{First, Rest}[cpp$postTagSystemFinalState[initHead, initTape, maxEventCount]]]
+  Through[{#[[2]] &, #[[3 ;; ]] &}[cpp$evaluatePostTagSystem[initHead, initTape, maxEventCount]]]
 
 postTagSystemFinalState[init : Except[{_, _}], _] := throw[Failure["invalidStateFormat", <|"init" -> init|>]];
 

--- a/Kernel/cpp.m
+++ b/Kernel/cpp.m
@@ -12,7 +12,7 @@ PackageScope["cpp$stateSuccessors"]
 PackageScope["cpp$state"]
 PackageScope["cpp$cycleSources"]
 PackageScope["cpp$initStates"]
-PackageScope["cpp$postTagSystemFinalState"]
+PackageScope["cpp$evaluatePostTagSystem"]
 
 (* this function is defined now, but only run the *next* time Kernel/init.m is called, before all symbols
 are cleared. *)
@@ -98,13 +98,13 @@ $libraryFunctions = {
      {Integer, 1}],
     $Failed],
 
-  cpp$postTagSystemFinalState = If[$libraryFile =!= $Failed,
+  cpp$evaluatePostTagSystem = If[$libraryFile =!= $Failed,
     LibraryFunctionLoad[
       $libraryFile,
-      "postTagSystemFinalState",
+      "evaluatePostTagSystem",
       {Integer,      (* head state *)
        {Integer, 1}, (* tape state *)
        Integer},     (* event count *)
-      {Integer, 1}], (* {headState, tape[[1]], tape[[2]], ...} *)
+      {Integer, 1}], (* {eventCount, headState, tape[[1]], tape[[2]], ...} *)
     $Failed]
 };

--- a/Tests/GeneratePostTagSystemHistory.wlt
+++ b/Tests/GeneratePostTagSystemHistory.wlt
@@ -1,0 +1,69 @@
+<|
+  "GeneratePostTagSystemHistory" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
+      Global`testUnevaluated[args___] := PostTagSystem`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := PostTagSystem`PackageScope`testSymbolLeak[VerificationTest, args];
+    ),
+    "tests" -> {
+      testSymbolLeak[GeneratePostTagSystemHistory[{0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, 20858048]],
+
+      With[{nineZeros = ConstantArray[0, 9]}, {
+        testUnevaluated[GeneratePostTagSystemHistory[], {GeneratePostTagSystemHistory::invalidArgumentCount}],
+        testUnevaluated[GeneratePostTagSystemHistory[1, 2, 3], {GeneratePostTagSystemHistory::invalidArgumentCount}],
+        testUnevaluated[GeneratePostTagSystemHistory[#, 8],
+                        {GeneratePostTagSystemHistory::invalidStateFormat}] & /@ {1, {1, 2, 3}, {1}},
+        testUnevaluated[GeneratePostTagSystemHistory[{#, nineZeros}, 8],
+                        {GeneratePostTagSystemHistory::invalidInitPhase}] & /@ {-1, 3, "x"},
+        testUnevaluated[GeneratePostTagSystemHistory[{0, #}, 8],
+                        {GeneratePostTagSystemHistory::invalidInitTape}] & /@ {0, "x", {"x"}, {-1}, {2}, {0, 1, 2}},
+        testUnevaluated[GeneratePostTagSystemHistory[{0, nineZeros}, #],
+                        {GeneratePostTagSystemHistory::eventCountNotInteger}] & /@ {"x", 2.3},
+        testUnevaluated[GeneratePostTagSystemHistory[{0, nineZeros}, -1],
+                        {GeneratePostTagSystemHistory::eventCountNegative}],
+        testUnevaluated[GeneratePostTagSystemHistory[{0, nineZeros}, 9223372036854775808 (* 2^63 *)],
+                        {GeneratePostTagSystemHistory::eventCountTooLarge}],
+        testUnevaluated[GeneratePostTagSystemHistory[{0, nineZeros}, #],
+                        {GeneratePostTagSystemHistory::eventCountUneven}] & /@ {1, 2, 3, 4, 5, 6, 7, 9, 100},
+
+        VerificationTest[GeneratePostTagSystemHistory[{0, {0, 0, 0, 0, 0, 0, 0, 0, 0}}, 8],
+                         <|"EventCount" -> 8, "FinalState" -> {1, {0, 0, 0, 0, 0, 0, 0}}|>],
+        VerificationTest[GeneratePostTagSystemHistory[{2, {1, 1, 1, 1, 1, 1, 1, 1, 1}}, 8],
+                         <|"EventCount" -> 8, "FinalState" -> {1, {1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1}}|>],
+        VerificationTest[GeneratePostTagSystemHistory[{0, {}}, 8], <|"EventCount" -> 0, "FinalState" -> {0, {}}|>],
+        VerificationTest[GeneratePostTagSystemHistory[{0, {0}}, 8], <|"EventCount" -> 0, "FinalState" -> {0, {0}}|>],
+        VerificationTest[GeneratePostTagSystemHistory[{0, nineZeros}, 0],
+                         <|"EventCount" -> 0, "FinalState" -> {0, nineZeros}|>],
+
+        VerificationTest[GeneratePostTagSystemHistory[{0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, 20858040],
+                         <|"EventCount" -> 20858040, "FinalState" -> {2, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}|>],
+        VerificationTest[GeneratePostTagSystemHistory[{0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, #],
+                         <|"EventCount" -> 20858048, "FinalState" -> {0, {0, 0, 0, 0, 0, 0, 0}}|>] & /@
+          {20858048, 20858048 + 8, 2^32 - 8, 2^63 - 8},
+
+        randomInit[seed_] := ModuleScope[BlockRandom[
+          phase = RandomInteger[{0, 2}];
+          length = RandomInteger[{9, 14}];
+          tape = RandomInteger[1, length];
+          {phase, tape}
+        , RandomSeeding -> seed]];
+
+        stateList[init_, stride_, minSize_] := ModuleScope[
+          system = PostTagSystem[init];
+          statesOfAnySize = system["State", #] & /@ Range[1, system["StateCount"], stride];
+          firstSmallState =
+            FirstPosition[statesOfAnySize, {_, _ ? (Length[#] <= minSize &)}, {Length[statesOfAnySize]}, {1}][[1]];
+          statesOfAnySize[[1 ;; firstSmallState]]
+        ];
+
+        With[{randomInits = randomInit /@ Range[1000]},
+          Function[{init}, MapIndexed[With[{
+              eventCount = 8 * (#2[[1]] - 1)},
+            VerificationTest[GeneratePostTagSystemHistory[init, eventCount],
+                             <|"EventCount" -> eventCount, "FinalState" -> #1|>]
+          ] &, stateList[init, 8, 8]]] /@ randomInits
+        ]
+      }]
+    }
+  |>
+|>

--- a/Tests/PostTagSystemFinalState.wlt
+++ b/Tests/PostTagSystemFinalState.wlt
@@ -19,46 +19,23 @@
                         {PostTagSystemFinalState::invalidInitTape}] & /@ {0, "x", {"x"}, {-1}, {2}, {0, 1, 2}},
         testUnevaluated[PostTagSystemFinalState[{0, nineZeros}, #],
                         {PostTagSystemFinalState::eventCountNotInteger}] & /@ {"x", 2.3},
-        testUnevaluated[PostTagSystemFinalState[{0, nineZeros}, -1], {PostTagSystemFinalState::eventCountNegative}],
+        testUnevaluated[PostTagSystemFinalState[{0, nineZeros}, -1],
+                        {PostTagSystemFinalState::eventCountNegative}],
         testUnevaluated[PostTagSystemFinalState[{0, nineZeros}, 9223372036854775808 (* 2^63 *)],
                         {PostTagSystemFinalState::eventCountTooLarge}],
         testUnevaluated[PostTagSystemFinalState[{0, nineZeros}, #],
-                        {PostTagSystemFinalState::eventCountUneven}] & /@ {1, 2, 3, 4, 5, 6, 7, 9, 100},
+                        {PostTagSystemFinalState::eventCountUneven}] & /@ {1, 2, 3, 4, 5, 6, 7, 9, 100}
+      }],
 
-        VerificationTest[PostTagSystemFinalState[{0, {0, 0, 0, 0, 0, 0, 0, 0, 0}}, 8], {1, {0, 0, 0, 0, 0, 0, 0}}],
-        VerificationTest[PostTagSystemFinalState[{2, {1, 1, 1, 1, 1, 1, 1, 1, 1}}, 8],
-                         {1, {1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1}}],
-        VerificationTest[PostTagSystemFinalState[{0, {}}, 8], {0, {}}],
-        VerificationTest[PostTagSystemFinalState[{0, {0}}, 8], {0, {0}}],
-        VerificationTest[PostTagSystemFinalState[{0, nineZeros}, 0], {0, nineZeros}],
-
-        VerificationTest[PostTagSystemFinalState[{0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, 20858040],
-                         {2, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}],
-        VerificationTest[PostTagSystemFinalState[{0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, #],
-                         {0, {0, 0, 0, 0, 0, 0, 0}}] & /@ {20858048, 20858048 + 8, 2^32 - 8, 2^63 - 8},
-
-        randomInit[seed_] := ModuleScope[BlockRandom[
-          phase = RandomInteger[{0, 2}];
-          length = RandomInteger[{9, 14}];
-          tape = RandomInteger[1, length];
-          {phase, tape}
-        , RandomSeeding -> seed]];
-
-        stateList[init_, stride_, minSize_] := ModuleScope[
-          system = PostTagSystem[init];
-          statesOfAnySize = system["State", #] & /@ Range[1, system["StateCount"], stride];
-          firstSmallState =
-            FirstPosition[statesOfAnySize, {_, _ ? (Length[#] <= minSize &)}, {Length[statesOfAnySize]}, {1}][[1]];
-          statesOfAnySize[[1 ;; firstSmallState]]
-        ];
-
-        With[{randomInits = randomInit /@ Range[1000]},
-          Function[{init}, MapIndexed[With[{
-              eventCount = 8 * (#2[[1]] - 1)},
-            VerificationTest[PostTagSystemFinalState[init, eventCount], #1]
-          ] &, stateList[init, 8, 8]]] /@ randomInits
+      BlockRandom[Table[
+        With[{
+            initTape = RandomInteger[1, RandomInteger[100]],
+            initPhase = RandomInteger[2],
+            eventCount = 8 * RandomInteger[100]},
+          VerificationTest[PostTagSystemFinalState[{initPhase, initTape}, eventCount],
+                           GeneratePostTagSystemHistory[{initPhase, initTape}, eventCount]["FinalState"]]
         ]
-      }]
+      , 1000], RandomSeeding -> 0]
     }
   |>
 |>

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -10,8 +10,13 @@
 namespace PostTagSystem {
 class PostTagHistory {
  public:
+  struct EvaluationResult {
+    PostTagState finalState;
+    uint64_t eventCount;
+  };
+
   PostTagHistory();
-  PostTagState evaluate(const PostTagState& init, uint64_t maxEvents) const;
+  EvaluationResult evaluate(const PostTagState& init, uint64_t maxEvents) const;
 
  private:
   class Implementation;

--- a/libPostTagSystem/WolframLanguageAPI.hpp
+++ b/libPostTagSystem/WolframLanguageAPI.hpp
@@ -34,9 +34,6 @@ EXTERN_C DLLEXPORT int cycleSources(WolframLibraryData libData, mint argc, MArgu
 
 EXTERN_C DLLEXPORT int initStates(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
-EXTERN_C DLLEXPORT int postTagSystemFinalState(WolframLibraryData libData,
-                                               mint argc,
-                                               MArgument* argv,
-                                               MArgument result);
+EXTERN_C DLLEXPORT int evaluatePostTagSystem(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
 #endif  // LIBPOSTTAGSYSTEM_WOLFRAMLANGUAGEAPI_HPP_

--- a/libPostTagSystem/test/PostTagSystem_test.cpp
+++ b/libPostTagSystem/test/PostTagSystem_test.cpp
@@ -18,10 +18,10 @@ TEST(PostTagSystem, simpleEvolution) {
 
 TEST(PostTagSystem, chunkEvaluationTable) {
   PostTagHistory history;
-  ASSERT_EQ(history.evaluate({{1, 0, 1, 1, 1, 0, 1, 1, 1}, 2}, 0).tape[8], 1);
-  ASSERT_EQ(history.evaluate({{1, 0, 1, 1, 1, 0, 1, 1, 1}, 2}, 8).tape.size(), 10);
-  ASSERT_EQ(history.evaluate({{1, 0, 1, 1, 1, 0, 1, 1}, 0}, 0).tape.size(), 8);
-  ASSERT_EQ(history.evaluate({{1, 1, 1, 1, 1, 1, 1, 1, 0}, 2}, 8).tape.size(), 12);
-  ASSERT_EQ(history.evaluate({{}, 0}, 8).tape.size(), 0);
+  ASSERT_EQ(history.evaluate({{1, 0, 1, 1, 1, 0, 1, 1, 1}, 2}, 0).finalState.tape[8], 1);
+  ASSERT_EQ(history.evaluate({{1, 0, 1, 1, 1, 0, 1, 1, 1}, 2}, 8).finalState.tape.size(), 10);
+  ASSERT_EQ(history.evaluate({{1, 0, 1, 1, 1, 0, 1, 1}, 0}, 0).finalState.tape.size(), 8);
+  ASSERT_EQ(history.evaluate({{1, 1, 1, 1, 1, 1, 1, 1, 0}, 2}, 8).finalState.tape.size(), 12);
+  ASSERT_EQ(history.evaluate({{}, 0}, 8).finalState.tape.size(), 0);
 }
 }  // namespace PostTagSystem


### PR DESCRIPTION
## Changes

* Adds GeneratePostTagSystemHistory function that returns an association with evaluation results, including `"EventCount"` and `"FinalState"`.
* This makes it easier to use the evaluation function because one can tell whether the requested event count ran or not.

## Examples

* Obtain the number of events produced in an evolution:

```wl
In[] := GeneratePostTagSystemHistory[{0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, 10^9]
Out[] = <|"EventCount" -> 20858048, "FinalState" -> {0, {0, 0, 0, 0, 0, 0, 0}}|>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/4)
<!-- Reviewable:end -->
