### PR TITLE
Checkpoints

### DIFF
--- a/Kernel/GeneratePostTagSystemHistory.m
+++ b/Kernel/GeneratePostTagSystemHistory.m
@@ -10,10 +10,12 @@ SetUsage @ "
 GeneratePostTagSystemHistory[{initPhase$, initTape$}, maxEventCount$] computes the evolution of the Post tag system \
 starting from a state with head initPhase$ and tape initTape$ for at most maxEventCount$ events, and returns an \
 association containing information about that evolution.
+GeneratePostTagSystemHistory[init$, maxEventCount$, checkpointList$] terminates the evolution once any of the states \
+from checkpointList$ is reached. The states in checkpointList$ are specified using the same format as init$.
 If the system reaches a state with <= 8 tape cells before maxEventCount$ is reached, that state is returned instead.
 ";
 
-SyntaxInformation[GeneratePostTagSystemHistory] = {"ArgumentsPattern" -> {init_, maxEventCount_}};
+SyntaxInformation[GeneratePostTagSystemHistory] = {"ArgumentsPattern" -> {init_, maxEventCount_, checkpointList_.}};
 
 declareMessage[General::invalidStateFormat, "Initial state `init` in `expr` must be a pair {phase, tape}."];
 declareMessage[General::invalidInitPhase, "Initial phase `initPhase` in `expr` must be 0, 1, or 2."];
@@ -22,7 +24,10 @@ declareMessage[General::eventCountNotInteger, "Max event count `eventCount` in `
 declareMessage[General::eventCountNegative, "Max event count `eventCount` in `expr` must not be negative."];
 declareMessage[General::eventCountTooLarge, "Max event count `eventCount` in `expr` must be smaller than 2^63."];
 declareMessage[General::eventCountUneven, "Max event count `eventCount` in `expr` must be a multiple of 8."];
-declareMessage[General::invalidArgumentCount, "Expected `expected` arguments in `expr` instead of `actual`."];
+declareMessage[General::invalidCheckpoints,
+               "The list of checkpoints `checkpoints` in `expr` must be a single state or a list of states."];
+declareMessage[General::invalidArgumentCountRange,
+               "Expected between `expectedMin` and `expectedMax` arguments in `expr` instead of `actual`."];
 
 expr : GeneratePostTagSystemHistory[args___] := ModuleScope[
   result = Catch[generatePostTagSystemHistory[args],
@@ -31,11 +36,23 @@ expr : GeneratePostTagSystemHistory[args___] := ModuleScope[
   result /; !FailureQ[result]
 ];
 
+$statePattern = {0 | 1 | 2, {(0 | 1) ...}};
+$maxEventCountPattern = (_Integer ? (0 <= # < 2^63 && Mod[#, 8] == 0 &));
+
 generatePostTagSystemHistory[{initHead : 0 | 1 | 2, initTape : {(0 | 1) ...}},
-                        maxEventCount_Integer ? (0 <= # < 2^63 && Mod[#, 8] == 0 &)] := ModuleScope[
-  cppOutput = cpp$evaluatePostTagSystem[initHead, initTape, maxEventCount];
+                             maxEventCount : $maxEventCountPattern,
+                             checkpoints : {$statePattern ...} : {}] := ModuleScope[
+  cppOutput = cpp$evaluatePostTagSystem[initHead,
+                                        initTape,
+                                        maxEventCount,
+                                        First /@ checkpoints,
+                                        Length /@ Last /@ checkpoints,
+                                        Catenate[Last /@ checkpoints]];
   <|"EventCount" -> First[cppOutput], "FinalState" -> Through[{#[[2]] &, #[[3 ;; ]] &}[cppOutput]]|>
 ];
+
+generatePostTagSystemHistory[init : $statePattern, maxEventCount : $maxEventCountPattern, checkpoint : $statePattern] :=
+  generatePostTagSystemHistory[init, maxEventCount, {checkpoint}];
 
 generatePostTagSystemHistory[init : Except[{_, _}], _] := throw[Failure["invalidStateFormat", <|"init" -> init|>]];
 
@@ -57,5 +74,8 @@ generatePostTagSystemHistory[{_, _}, maxEventCount_Integer ? (# >= 2^63 &)] :=
 generatePostTagSystemHistory[{_, _}, maxEventCount_Integer ? (0 <= # < 2^63 && Mod[#, 8] != 0 &)] :=
   throw[Failure["eventCountUneven", <|"eventCount" -> maxEventCount|>]];
 
+generatePostTagSystemHistory[{_, _}, _, checkpoints : Except[$statePattern | {$statePattern ...}]] :=
+  throw[Failure["invalidCheckpoints", <|"checkpoints" -> checkpoints|>]];
+
 generatePostTagSystemHistory[args___] :=
-  throw[Failure["invalidArgumentCount", <|"expected" -> 2, "actual" -> Length[{args}]|>]];
+  throw[Failure["invalidArgumentCountRange", <|"expectedMin" -> 2, "expectedMax" -> 3, "actual" -> Length[{args}]|>]];

--- a/Kernel/cpp.m
+++ b/Kernel/cpp.m
@@ -102,9 +102,12 @@ $libraryFunctions = {
     LibraryFunctionLoad[
       $libraryFile,
       "evaluatePostTagSystem",
-      {Integer,      (* head state *)
-       {Integer, 1}, (* tape state *)
-       Integer},     (* event count *)
+      {Integer,       (* head state *)
+       {Integer, 1},  (* tape state *)
+       Integer,       (* event count *)
+       {Integer, 1},  (* checkpoint heads *)
+       {Integer, 1},  (* checkpoint lengths *)
+       {Integer, 1}}, (* catenated checkpoint tapes *)
       {Integer, 1}], (* {eventCount, headState, tape[[1]], tape[[2]], ...} *)
     $Failed]
 };

--- a/Tests/PostTagSystemFinalState.wlt
+++ b/Tests/PostTagSystemFinalState.wlt
@@ -9,8 +9,8 @@
       testSymbolLeak[PostTagSystemFinalState[{0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, 20858048]],
 
       With[{nineZeros = ConstantArray[0, 9]}, {
-        testUnevaluated[PostTagSystemFinalState[], {PostTagSystemFinalState::invalidArgumentCount}],
-        testUnevaluated[PostTagSystemFinalState[1, 2, 3], {PostTagSystemFinalState::invalidArgumentCount}],
+        testUnevaluated[PostTagSystemFinalState[], {PostTagSystemFinalState::invalidArgumentCountRange}],
+        testUnevaluated[PostTagSystemFinalState[1, 2, 3], {PostTagSystemFinalState::invalidArgumentCountRange}],
         testUnevaluated[PostTagSystemFinalState[#, 8],
                         {PostTagSystemFinalState::invalidStateFormat}] & /@ {1, {1, 2, 3}, {1}},
         testUnevaluated[PostTagSystemFinalState[{#, nineZeros}, 8],

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -16,7 +16,9 @@ class PostTagHistory {
   };
 
   PostTagHistory();
-  EvaluationResult evaluate(const PostTagState& init, uint64_t maxEvents) const;
+  EvaluationResult evaluate(const PostTagState& init,
+                            uint64_t maxEvents,
+                            const std::vector<PostTagState>& checkpoints = {}) const;
 
  private:
   class Implementation;

--- a/libPostTagSystem/test/PostTagSystem_test.cpp
+++ b/libPostTagSystem/test/PostTagSystem_test.cpp
@@ -24,4 +24,25 @@ TEST(PostTagSystem, chunkEvaluationTable) {
   ASSERT_EQ(history.evaluate({{1, 1, 1, 1, 1, 1, 1, 1, 0}, 2}, 8).finalState.tape.size(), 12);
   ASSERT_EQ(history.evaluate({{}, 0}, 8).finalState.tape.size(), 0);
 }
+
+TEST(PostTagHistory, checkpoints) {
+  PostTagHistory history;
+  const PostTagState init = {{0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}, 0};
+  constexpr uint64_t lateCheckpointEventCount = 20858000;
+  const PostTagState lateCheckpoint = {{0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0}, 2};
+  const auto lateEvaluationResult = history.evaluate(init, 10 * lateCheckpointEventCount, {lateCheckpoint});
+  ASSERT_EQ(lateEvaluationResult.eventCount, lateCheckpointEventCount);
+  ASSERT_EQ(lateEvaluationResult.finalState.headState, lateCheckpoint.headState);
+  ASSERT_EQ(lateEvaluationResult.finalState.tape, lateCheckpoint.tape);
+
+  constexpr uint64_t earlyCheckpointEventCount = 20857000;
+  const PostTagState earlyCheckpoint = {{1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1,
+                                         1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1},
+                                        1};
+  const auto earlyEvaluationResult =
+      history.evaluate(init, 10 * lateCheckpointEventCount, {lateCheckpoint, earlyCheckpoint});
+  ASSERT_EQ(earlyEvaluationResult.eventCount, earlyCheckpointEventCount);
+  ASSERT_EQ(earlyEvaluationResult.finalState.headState, earlyCheckpoint.headState);
+  ASSERT_EQ(earlyEvaluationResult.finalState.tape, earlyCheckpoint.tape);
+}
 }  // namespace PostTagSystem


### PR DESCRIPTION
## Changes

* Implements checkpoints to `GeneratePostTagSystemHistory` and `PostTagSystemFinalState`.
* Allows one to specify states which, if reach, should stop the evolution.

## Comments

* The next step would be generating these checkpoints at runtime at exponentially-increasing event numbers, which would allow one to detect arbitrary cycles in O(n log(n)).
* Note that only states after 8n events will be detected. Intermediate states will be missed.
* I did not test the effect on performance yet, but it should not be significant, as (1) in no checkpoints case, it just adds an empty for-loop to the bit-packed evolution code, and (2) checkpoint comparison is done on bit-packed states and terminates immediately in case of any mismatch.

## Examples

* Terminate the Post Tag System early once a checkpoint is reached also obtaining the number of events it took to reach it:
```wl
In[] := GeneratePostTagSystemHistory[{0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}},
                                     208570000,
                                     {2, {0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0}}]
Out[] = <|"EventCount" -> 20858000,
          "FinalState" -> {2, {0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0}}|>
```

* Evolve directly to verify:
```wl
In[] := PostTagSystemFinalState[{0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, 20858000]
Out[] = {2, {0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0}}
```

* Multiple checkpoints are also supported:
```wl
In[] := GeneratePostTagSystemHistory[{0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}},
                                     208570000,
                                     {{2, {0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0}},
                                      {1, {1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1,
                                           1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1}}}]
Out[] = <|"EventCount" -> 20857000,
          "FinalState" -> {1, {1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1,
                               1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1}}|>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/5)
<!-- Reviewable:end -->
