### PR TITLE
Fix macOS CMake to a specific version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,14 +133,10 @@ jobs:
       - run:
           name: Install CMake
           command: |
-            cmakeURL=$(\
-              curl -s https://api.github.com/repos/Kitware/CMake/releases/latest \
-              | grep 'browser_download_url' \
-              | cut -d\" -f4 \
-              | grep macos-universal.tar.gz)
-            curl -L --output cmake-macos-universal.tar.gz $cmakeURL
-            tar xf cmake-macos-universal.tar.gz
-            cmakeDir=$(ls | grep cmake-*-macos-universal)
+            cmakeURL="https://github.com/Kitware/CMake/releases/download/v3.18.6/cmake-3.18.6-Darwin-x86_64.tar.gz"
+            curl -L --output cmake.tar.gz $cmakeURL
+            tar xf cmake.tar.gz
+            cmakeDir=$(ls | grep cmake-*)
             mkdir -p /usr/local/bin /usr/local/share
             cp -r $cmakeDir/CMake.app/Contents/bin/* /usr/local/bin/
             cp -r $cmakeDir/CMake.app/Contents/share/* /usr/local/share/


### PR DESCRIPTION
## Changes

* Fixes CMake link in CI on macOS to use a specific version as it got broken with the latest release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/6)
<!-- Reviewable:end -->
