### PR TITLE
System 002211

### DIFF
--- a/Kernel/GeneratePostTagSystemHistory.m
+++ b/Kernel/GeneratePostTagSystemHistory.m
@@ -17,18 +17,6 @@ If the system reaches a state with <= 8 tape cells before maxEventCount$ is reac
 
 SyntaxInformation[GeneratePostTagSystemHistory] = {"ArgumentsPattern" -> {init_, maxEventCount_, checkpointList_.}};
 
-declareMessage[General::invalidStateFormat, "Initial state `init` in `expr` must be a pair {phase, tape}."];
-declareMessage[General::invalidInitPhase, "Initial phase `initPhase` in `expr` must be 0, 1, or 2."];
-declareMessage[General::invalidInitTape, "Initial tape `initTape` in `expr` must be a list of 0s and 1s."];
-declareMessage[General::eventCountNotInteger, "Max event count `eventCount` in `expr` must be an integer."];
-declareMessage[General::eventCountNegative, "Max event count `eventCount` in `expr` must not be negative."];
-declareMessage[General::eventCountTooLarge, "Max event count `eventCount` in `expr` must be smaller than 2^63."];
-declareMessage[General::eventCountUneven, "Max event count `eventCount` in `expr` must be a multiple of 8."];
-declareMessage[General::invalidCheckpoints,
-               "The list of checkpoints `checkpoints` in `expr` must be a single state or a list of states."];
-declareMessage[General::invalidArgumentCountRange,
-               "Expected between `expectedMin` and `expectedMax` arguments in `expr` instead of `actual`."];
-
 expr : GeneratePostTagSystemHistory[args___] := ModuleScope[
   result = Catch[generatePostTagSystemHistory[args],
                  _ ? FailureQ,
@@ -36,46 +24,4 @@ expr : GeneratePostTagSystemHistory[args___] := ModuleScope[
   result /; !FailureQ[result]
 ];
 
-$statePattern = {0 | 1 | 2, {(0 | 1) ...}};
-$maxEventCountPattern = (_Integer ? (0 <= # < 2^63 && Mod[#, 8] == 0 &));
-
-generatePostTagSystemHistory[{initHead : 0 | 1 | 2, initTape : {(0 | 1) ...}},
-                             maxEventCount : $maxEventCountPattern,
-                             checkpoints : {$statePattern ...} : {}] := ModuleScope[
-  cppOutput = cpp$evaluatePostTagSystem[initHead,
-                                        initTape,
-                                        maxEventCount,
-                                        First /@ checkpoints,
-                                        Length /@ Last /@ checkpoints,
-                                        Catenate[Last /@ checkpoints]];
-  <|"EventCount" -> First[cppOutput], "FinalState" -> Through[{#[[2]] &, #[[3 ;; ]] &}[cppOutput]]|>
-];
-
-generatePostTagSystemHistory[init : $statePattern, maxEventCount : $maxEventCountPattern, checkpoint : $statePattern] :=
-  generatePostTagSystemHistory[init, maxEventCount, {checkpoint}];
-
-generatePostTagSystemHistory[init : Except[{_, _}], _] := throw[Failure["invalidStateFormat", <|"init" -> init|>]];
-
-generatePostTagSystemHistory[{initHead : Except[0 | 1 | 2], _}, _] :=
-  throw[Failure["invalidInitPhase", <|"initPhase" -> initHead|>]];
-
-generatePostTagSystemHistory[{_, initTape : Except[{(0 | 1) ...}]}, _] :=
-  throw[Failure["invalidInitTape", <|"initTape" -> initTape|>]];
-
-generatePostTagSystemHistory[{_, _}, maxEventCount : Except[_Integer]] :=
-  throw[Failure["eventCountNotInteger", <|"eventCount" -> maxEventCount|>]];
-
-generatePostTagSystemHistory[{_, _}, maxEventCount_Integer ? (# < 0 &)] :=
-  throw[Failure["eventCountNegative", <|"eventCount" -> maxEventCount|>]];
-
-generatePostTagSystemHistory[{_, _}, maxEventCount_Integer ? (# >= 2^63 &)] :=
-  throw[Failure["eventCountTooLarge", <|"eventCount" -> maxEventCount|>]];
-
-generatePostTagSystemHistory[{_, _}, maxEventCount_Integer ? (0 <= # < 2^63 && Mod[#, 8] != 0 &)] :=
-  throw[Failure["eventCountUneven", <|"eventCount" -> maxEventCount|>]];
-
-generatePostTagSystemHistory[{_, _}, _, checkpoints : Except[$statePattern | {$statePattern ...}]] :=
-  throw[Failure["invalidCheckpoints", <|"checkpoints" -> checkpoints|>]];
-
-generatePostTagSystemHistory[args___] :=
-  throw[Failure["invalidArgumentCountRange", <|"expectedMin" -> 2, "expectedMax" -> 3, "actual" -> Length[{args}]|>]];
+generatePostTagSystemHistory[args___] := generateTagSystemHistory["Post", args];

--- a/Kernel/GenerateTagSystemHistory.m
+++ b/Kernel/GenerateTagSystemHistory.m
@@ -1,0 +1,104 @@
+Package["PostTagSystem`"]
+
+PackageImport["GeneralUtilities`"]
+
+PackageExport["GenerateTagSystemHistory"]
+
+PackageScope["generateTagSystemHistory"]
+
+SetUsage @ "
+GenerateTagSystemHistory[system$, {initPhase$, initTape$}, maxEventCount$] computes the evolution of the named tag \
+system$ starting from a state with head initPhase$ and tape initTape$ for at most maxEventCount$ events, and returns \
+an association containing information about that evolution.
+GeneratePostTagSystemHistory[system$, init$, maxEventCount$, checkpointList$] terminates the evolution once any of the \
+states from checkpointList$ is reached. The states in checkpointList$ are specified using the same format as init$.
+If the system reaches a state with <= 8 bits of tape cells before maxEventCount$ is reached, that state is returned \
+instead.
+";
+
+SyntaxInformation[GenerateTagSystemHistory] =
+  {"ArgumentsPattern" -> {system_, init_, maxEventCount_, checkpointList_.}};
+
+declareMessage[General::invalidSystem, "Tag system `system` in `expr` should be one of `systemList`."];
+declareMessage[General::invalidStateFormat, "Initial state `init` in `expr` must be a pair {phase, tape}."];
+declareMessage[General::invalidInitPhase, "Initial phase `initPhase` in `expr` must be 0, 1, or 2."];
+declareMessage[General::invalidInitTape, "Initial tape `initTape` in `expr` must be a list of 0s and 1s."];
+declareMessage[General::eventCountNotInteger, "Max event count `eventCount` in `expr` must be an integer."];
+declareMessage[General::eventCountNegative, "Max event count `eventCount` in `expr` must not be negative."];
+declareMessage[General::eventCountTooLarge, "Max event count `eventCount` in `expr` must be smaller than 2^63."];
+declareMessage[General::eventCountUneven,
+               "Max event count `eventCount` in `expr` must be a multiple of `stepsAtATime`."];
+declareMessage[General::invalidCheckpoints,
+               "The list of checkpoints `checkpoints` in `expr` must be a single state or a list of states."];
+declareMessage[General::invalidArgumentCountRange,
+               "Expected between `expectedMin` and `expectedMax` arguments in `expr` instead of `actual`."];
+
+expr : GenerateTagSystemHistory[args___] := ModuleScope[
+  result = Catch[generateTagSystemHistory[args],
+                 _ ? FailureQ,
+                 message[GenerateTagSystemHistory, #, <|"expr" -> HoldForm[expr]|>] &];
+  result /; !FailureQ[result]
+];
+
+$systems = <|"Post" -> 0, "002211" -> 1|>;
+
+With[{systems = Keys[$systems]},
+  FE`Evaluate[FEPrivate`AddSpecialArgCompletion["GenerateTagSystemHistory" -> {systems, 0, 0, 0}]]
+];
+
+$systemPattern = Alternatives @@ Keys[$systems];
+$statePattern = {0 | 1 | 2, {(0 | 1) ...}};
+
+$stepsAtATime = <|"Post" -> 8, "002211" -> 4|>;
+maxEventCountPattern[system_] := (_Integer ? (0 <= # < 2^63 && Mod[#, $stepsAtATime[system]] == 0 &));
+
+generateTagSystemHistory[system : $systemPattern,
+                         {initHead : 0 | 1 | 2, initTape : {(0 | 1) ...}},
+                         maxEventCount_,
+                         checkpoints : {$statePattern ...} : {}] /;
+    MatchQ[maxEventCount, maxEventCountPattern[system]] := ModuleScope[
+  cppOutput = cpp$evaluatePostTagSystem[$systems[system],
+                                        initHead,
+                                        initTape,
+                                        maxEventCount,
+                                        First /@ checkpoints,
+                                        Length /@ Last /@ checkpoints,
+                                        Catenate[Last /@ checkpoints]];
+  <|"EventCount" -> First[cppOutput], "FinalState" -> Through[{#[[2]] &, #[[3 ;; ]] &}[cppOutput]]|>
+];
+
+generateTagSystemHistory[
+      system : $systemPattern, init : $statePattern, maxEventCount_, checkpoint : $statePattern] /;
+    MatchQ[maxEventCount, maxEventCountPattern[system]] :=
+  generateTagSystemHistory[system, init, maxEventCount, {checkpoint}];
+
+generateTagSystemHistory[system : Except[$systemPattern], ___] :=
+  throw[Failure["invalidSystem", <|"system" -> system, "systemList" -> Keys[$systems]|>]];
+
+generateTagSystemHistory[$systemPattern, init : Except[{_, _}], ___] :=
+  throw[Failure["invalidStateFormat", <|"init" -> init|>]];
+
+generateTagSystemHistory[$systemPattern, {initHead : Except[0 | 1 | 2], _}, ___] :=
+  throw[Failure["invalidInitPhase", <|"initPhase" -> initHead|>]];
+
+generateTagSystemHistory[$systemPattern, {_, initTape : Except[{(0 | 1) ...}]}, ___] :=
+  throw[Failure["invalidInitTape", <|"initTape" -> initTape|>]];
+
+generateTagSystemHistory[$systemPattern, {_, _}, maxEventCount : Except[_Integer], ___] :=
+  throw[Failure["eventCountNotInteger", <|"eventCount" -> maxEventCount|>]];
+
+generateTagSystemHistory[$systemPattern, {_, _}, maxEventCount_Integer ? (# < 0 &), ___] :=
+  throw[Failure["eventCountNegative", <|"eventCount" -> maxEventCount|>]];
+
+generateTagSystemHistory[$systemPattern, {_, _}, maxEventCount_Integer ? (# >= 2^63 &), ___] :=
+  throw[Failure["eventCountTooLarge", <|"eventCount" -> maxEventCount|>]];
+
+generateTagSystemHistory[system : $systemPattern, {_, _}, maxEventCount_Integer ? (0 <= # < 2^63 &), ___] /;
+    Mod[maxEventCount, $stepsAtATime[system]] != 0 :=
+  throw[Failure["eventCountUneven", <|"eventCount" -> maxEventCount, "stepsAtATime" -> $stepsAtATime[system]|>]];
+
+generateTagSystemHistory[$systemPattern, {_, _}, _, checkpoints : Except[$statePattern | {$statePattern ...}], ___] :=
+  throw[Failure["invalidCheckpoints", <|"checkpoints" -> checkpoints|>]];
+
+generateTagSystemHistory[args___] :=
+  throw[Failure["invalidArgumentCountRange", <|"expectedMin" -> 3, "expectedMax" -> 4, "actual" -> Length[{args}]|>]];

--- a/Kernel/cpp.m
+++ b/Kernel/cpp.m
@@ -102,12 +102,13 @@ $libraryFunctions = {
     LibraryFunctionLoad[
       $libraryFile,
       "evaluatePostTagSystem",
-      {Integer,       (* head state *)
+      {Integer,       (* system ID *)
+       Integer,       (* head state *)
        {Integer, 1},  (* tape state *)
        Integer,       (* event count *)
        {Integer, 1},  (* checkpoint heads *)
        {Integer, 1},  (* checkpoint lengths *)
        {Integer, 1}}, (* catenated checkpoint tapes *)
-      {Integer, 1}], (* {eventCount, headState, tape[[1]], tape[[2]], ...} *)
+      {Integer, 1}],  (* {eventCount, headState, tape[[1]], tape[[2]], ...} *)
     $Failed]
 };

--- a/Tests/GeneratePostTagSystemHistory.wlt
+++ b/Tests/GeneratePostTagSystemHistory.wlt
@@ -11,7 +11,7 @@
       With[{nineZeros = ConstantArray[0, 9]}, {
         testUnevaluated[GeneratePostTagSystemHistory[], {GeneratePostTagSystemHistory::invalidArgumentCountRange}],
         testUnevaluated[GeneratePostTagSystemHistory[1, 2, 3],
-                        {GeneratePostTagSystemHistory::invalidArgumentCountRange}],
+                        {GeneratePostTagSystemHistory::invalidStateFormat}],
         testUnevaluated[GeneratePostTagSystemHistory[#, 8],
                         {GeneratePostTagSystemHistory::invalidStateFormat}] & /@ {1, {1, 2, 3}, {1}},
         testUnevaluated[GeneratePostTagSystemHistory[{#, nineZeros}, 8],

--- a/Tests/GenerateTagSystemHistory.wlt
+++ b/Tests/GenerateTagSystemHistory.wlt
@@ -1,0 +1,83 @@
+<|
+  "GenerateTagSystemHistory" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
+      Global`testUnevaluated[args___] := PostTagSystem`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := PostTagSystem`PackageScope`testSymbolLeak[VerificationTest, args];
+    ),
+    "tests" -> {
+      testSymbolLeak[GenerateTagSystemHistory["Post", {0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, 20858048]],
+
+      With[{nineZeros = ConstantArray[0, 9]}, {
+        testUnevaluated[GenerateTagSystemHistory[], {GenerateTagSystemHistory::invalidArgumentCountRange}],
+        testUnevaluated[GenerateTagSystemHistory["invalid", 1, 2], GenerateTagSystemHistory::invalidSystem],
+        testUnevaluated[GenerateTagSystemHistory["Post", 1, 2, 3],
+                        {GenerateTagSystemHistory::invalidStateFormat}],
+        testUnevaluated[GenerateTagSystemHistory["Post", #, 8],
+                        {GenerateTagSystemHistory::invalidStateFormat}] & /@ {1, {1, 2, 3}, {1}},
+        testUnevaluated[GenerateTagSystemHistory["Post", {#, nineZeros}, 8],
+                        {GenerateTagSystemHistory::invalidInitPhase}] & /@ {-1, 3, "x"},
+        testUnevaluated[GenerateTagSystemHistory["Post", {0, #}, 8],
+                        {GenerateTagSystemHistory::invalidInitTape}] & /@ {0, "x", {"x"}, {-1}, {2}, {0, 1, 2}},
+        testUnevaluated[GenerateTagSystemHistory["Post", {0, nineZeros}, #],
+                        {GenerateTagSystemHistory::eventCountNotInteger}] & /@ {"x", 2.3},
+        testUnevaluated[GenerateTagSystemHistory["Post", {0, nineZeros}, -1],
+                        {GenerateTagSystemHistory::eventCountNegative}],
+        testUnevaluated[GenerateTagSystemHistory["Post", {0, nineZeros}, 9223372036854775808 (* 2^63 *)],
+                        {GenerateTagSystemHistory::eventCountTooLarge}],
+        testUnevaluated[GenerateTagSystemHistory["Post", {0, nineZeros}, #],
+                        {GenerateTagSystemHistory::eventCountUneven}] & /@ {1, 2, 3, 4, 5, 6, 7, 9, 100},
+        testUnevaluated[GenerateTagSystemHistory["Post", {0, nineZeros}, 8, #],
+                        {GenerateTagSystemHistory::invalidCheckpoints}] & /@ {0, {0, 0}, {{0, nineZeros}, 0}},
+
+        VerificationTest[GenerateTagSystemHistory["Post", {0, {0, 0, 0, 0, 0, 0, 0, 0, 0}}, 8],
+                         <|"EventCount" -> 8, "FinalState" -> {1, {0, 0, 0, 0, 0, 0, 0}}|>],
+        VerificationTest[GenerateTagSystemHistory["Post", {2, {1, 1, 1, 1, 1, 1, 1, 1, 1}}, 8],
+                         <|"EventCount" -> 8, "FinalState" -> {1, {1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1}}|>],
+        VerificationTest[GenerateTagSystemHistory["Post", {0, {}}, 8], <|"EventCount" -> 0, "FinalState" -> {0, {}}|>],
+        VerificationTest[GenerateTagSystemHistory["Post", {0, {0}}, 8],
+                         <|"EventCount" -> 0, "FinalState" -> {0, {0}}|>],
+        VerificationTest[GenerateTagSystemHistory["Post", {0, nineZeros}, 0],
+                         <|"EventCount" -> 0, "FinalState" -> {0, nineZeros}|>],
+
+        VerificationTest[GenerateTagSystemHistory["Post", {0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, 20858040],
+                         <|"EventCount" -> 20858040, "FinalState" -> {2, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}|>],
+        VerificationTest[GenerateTagSystemHistory["Post", {0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, #],
+                         <|"EventCount" -> 20858048, "FinalState" -> {0, {0, 0, 0, 0, 0, 0, 0}}|>] & /@
+          {20858048, 20858048 + 8, 2^32 - 8, 2^63 - 8},
+
+        VerificationTest[GenerateTagSystemHistory["Post",
+                                                  {0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}},
+                                                  208570000,
+                                                  {2, {0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0}}],
+                         <|"EventCount" -> 20858000,
+                           "FinalState" -> {2, {0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0}}|>],
+        VerificationTest[
+          GenerateTagSystemHistory["Post",
+                                   {0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}},
+                                   208570000,
+                                   {{2, {0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0}},
+                                    {1, {1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1,
+                                         1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1}}}],
+          <|"EventCount" -> 20857000,
+            "FinalState" -> {1, {1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1,
+                                 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1}}|>],
+
+        VerificationTest[
+          GenerateTagSystemHistory["002211",
+                                   {0, {0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0}},
+                                   600],
+          <|"EventCount" -> 600,
+            "FinalState" -> {1, {1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1}}|>
+        ],
+
+        VerificationTest[
+          GenerateTagSystemHistory["002211",
+                                   {0, {0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0}},
+                                   656],
+          <|"EventCount" -> 656, "FinalState" -> {1, {0, 0, 1, 0, 0, 0, 0, 0, 0, 0}}|>
+        ]
+      }]
+    }
+  |>
+|>

--- a/Tests/PostTagSystemFinalState.wlt
+++ b/Tests/PostTagSystemFinalState.wlt
@@ -10,7 +10,7 @@
 
       With[{nineZeros = ConstantArray[0, 9]}, {
         testUnevaluated[PostTagSystemFinalState[], {PostTagSystemFinalState::invalidArgumentCountRange}],
-        testUnevaluated[PostTagSystemFinalState[1, 2, 3], {PostTagSystemFinalState::invalidArgumentCountRange}],
+        testUnevaluated[PostTagSystemFinalState[1, 2, 3], {PostTagSystemFinalState::invalidStateFormat}],
         testUnevaluated[PostTagSystemFinalState[#, 8],
                         {PostTagSystemFinalState::invalidStateFormat}] & /@ {1, {1, 2, 3}, {1}},
         testUnevaluated[PostTagSystemFinalState[{#, nineZeros}, 8],

--- a/libPostTagSystem/PostTagHistory.cpp
+++ b/libPostTagSystem/PostTagHistory.cpp
@@ -27,8 +27,8 @@ class PostTagHistory::Implementation {
   };
 
   struct ChunkedRule {
-    int tapeAtomLength;
-    int phaseCount;
+    uint8_t tapeAtomLength;
+    uint8_t phaseCount;
     std::vector<uint8_t> outputTapes;
     std::vector<uint8_t> outputLengths;
     std::vector<uint8_t> outputPhases;

--- a/libPostTagSystem/PostTagHistory.cpp
+++ b/libPostTagSystem/PostTagHistory.cpp
@@ -5,6 +5,7 @@
 #include <limits>
 #include <memory>
 #include <queue>
+#include <unordered_map>
 
 namespace PostTagSystem {
 class PostTagHistory::Implementation {
@@ -25,22 +26,37 @@ class PostTagHistory::Implementation {
     }
   };
 
-  static constexpr uint16_t chunkCount = 768;
-  using ChunkEvaluationTable = std::array<ChunkOutput, chunkCount>;
+  struct ChunkedRule {
+    int tapeAtomLength;
+    int phaseCount;
+    std::vector<uint8_t> outputTapes;
+    std::vector<uint8_t> outputLengths;
+    std::vector<uint8_t> outputPhases;
 
-  static constexpr uint8_t outputTapes[] = {0, 0, 0, 3, 0, 1};
-  static constexpr uint8_t outputLengths[] = {1, 0, 1, 2, 1, 1};
-  static constexpr uint8_t outputPhases[] = {2, 0, 1, 1, 2, 0};
+    uint32_t chunkCount() const { return 256 * phaseCount; }
+  };
 
-  const ChunkEvaluationTable chunkEvaluationTable_;
+  const std::unordered_map<NamedRule, ChunkedRule> rules{
+      {NamedRule::Post, {1, 3, {0, 0, 0, 3, 0, 1}, {1, 0, 1, 2, 1, 1}, {2, 0, 1, 1, 2, 0}}},
+      {NamedRule::Rule002211, {2, 2, {0, 0, 0, 2, 9, 1, 0, 0}, {1, 0, 1, 1, 2, 1, 0, 0}, {1, 0, 0, 1, 1, 0, 0, 0}}}};
+
+  struct ChunkEvaluationTable {
+    std::vector<ChunkOutput> outputs;
+    uint8_t phaseCount;
+    uint8_t eventsAtOnce;
+  };
+
+  std::unordered_map<NamedRule, ChunkEvaluationTable> evaluationTables_;
 
  public:
-  Implementation() : chunkEvaluationTable_(createChunkEvaluationTable()) {}
+  Implementation() {}
 
-  EvaluationResult evaluate(const PostTagState& init,
+  EvaluationResult evaluate(const NamedRule& rule,
+                            const PostTagState& init,
                             const uint64_t maxEvents,
-                            const std::vector<PostTagState>& checkpoints) const {
-    if (maxEvents % 8 != 0) {
+                            const std::vector<PostTagState>& checkpoints) {
+    const ChunkEvaluationTable chunkEvaluationTable = createChunkEvaluationTable(rule);
+    if (maxEvents % chunkEvaluationTable.eventsAtOnce != 0) {
       return {{}, std::numeric_limits<uint8_t>::max()};
     }
     auto chunkedState = toChunkedState(init);
@@ -49,35 +65,46 @@ class PostTagHistory::Implementation {
     for (const auto& checkpoint : checkpoints) {
       chunkedCheckpoints.push_back(toChunkedState(checkpoint));
     }
-    const auto eventCount = evaluate(&chunkedState, maxEvents, chunkedCheckpoints);
+    const auto eventCount = evaluate(chunkEvaluationTable, &chunkedState, maxEvents, chunkedCheckpoints);
     return {fromChunkedStateDestructively(&chunkedState), eventCount};
   }
 
  private:
-  ChunkEvaluationTable createChunkEvaluationTable() {
+  ChunkEvaluationTable createChunkEvaluationTable(const NamedRule& rule) {
+    auto foundTable = evaluationTables_.find(rule);
+    if (foundTable == evaluationTables_.end()) {
+      foundTable = evaluationTables_.insert({rule, createChunkEvaluationTable(rules.at(rule))}).first;
+    }
+    return foundTable->second;
+  }
+
+  ChunkEvaluationTable createChunkEvaluationTable(const ChunkedRule& rule) {
     ChunkEvaluationTable table;
+    table.eventsAtOnce = 8 / rule.tapeAtomLength;
+    table.phaseCount = rule.phaseCount;
+    table.outputs.resize(rule.chunkCount());
     uint8_t inputTape = std::numeric_limits<uint8_t>::max();
     do {
       ++inputTape;
-      for (uint8_t inputPhase = 0; inputPhase < 3; ++inputPhase) {
-        table[3 * inputTape + inputPhase] = createChunkOutput(inputTape, inputPhase);
+      for (uint8_t inputPhase = 0; inputPhase < rule.phaseCount; ++inputPhase) {
+        table.outputs[rule.phaseCount * inputTape + inputPhase] = createChunkOutput(rule, inputTape, inputPhase);
       }
     } while (inputTape != std::numeric_limits<uint8_t>::max());
     return table;
   }
 
-  ChunkOutput createChunkOutput(const uint8_t inputTape, const uint8_t inputPhase) {
+  ChunkOutput createChunkOutput(const ChunkedRule& rule, const uint8_t inputTape, const uint8_t inputPhase) const {
     uint16_t output = 0;
     uint8_t outputSize = 0;
     auto phase = inputPhase;
     auto shiftedInputTape = inputTape;
-    for (uint8_t i = 0; i < 8; ++i) {
-      bool poppedBit = (shiftedInputTape >> 7) & 1;
-      shiftedInputTape <<= 1;
-      uint8_t outputIndex = 3 * poppedBit + phase;
-      outputSize += outputLengths[outputIndex];
-      output = (output << outputLengths[outputIndex]) + outputTapes[outputIndex];
-      phase = outputPhases[outputIndex];
+    for (uint8_t i = 0; i < 8; i += rule.tapeAtomLength) {
+      uint8_t poppedBits = (shiftedInputTape >> (8 - rule.tapeAtomLength)) & (255 >> (8 - rule.tapeAtomLength));
+      shiftedInputTape <<= rule.tapeAtomLength;
+      uint8_t outputIndex = rule.phaseCount * poppedBits + phase;
+      outputSize += rule.outputLengths[outputIndex] * rule.tapeAtomLength;
+      output = (output << (rule.outputLengths[outputIndex] * rule.tapeAtomLength)) + rule.outputTapes[outputIndex];
+      phase = rule.outputPhases[outputIndex];
     }
     return {output, outputSize, phase};
   }
@@ -117,20 +144,24 @@ class PostTagHistory::Implementation {
     }
   }
 
-  uint64_t evaluate(ChunkedState* state, const uint64_t maxEvents, const std::vector<ChunkedState>& checkpoints) const {
+  uint64_t evaluate(const ChunkEvaluationTable& evaluationTable,
+                    ChunkedState* state,
+                    const uint64_t maxEvents,
+                    const std::vector<ChunkedState>& checkpoints) const {
     uint64_t eventCount;
-    for (eventCount = 0; eventCount < maxEvents && state->chunks.size() > 1; eventCount += 8) {
+    for (eventCount = 0; eventCount < maxEvents && state->chunks.size() > 1;
+         eventCount += evaluationTable.eventsAtOnce) {
       for (const auto& checkpoint : checkpoints) {
         if (checkpoint == *state) return eventCount;
       }
-      evaluateOnce(state);
+      evaluateOnce(evaluationTable, state);
     }
     return eventCount;
   }
 
-  void evaluateOnce(ChunkedState* state) const {
-    const auto nextChunkIndex = 3 * state->chunks.front() + state->phase;
-    const auto& chunkOutput = chunkEvaluationTable_[nextChunkIndex];
+  void evaluateOnce(const ChunkEvaluationTable& evaluationTable, ChunkedState* state) const {
+    const auto nextChunkIndex = evaluationTable.phaseCount * state->chunks.front() + state->phase;
+    const auto& chunkOutput = evaluationTable.outputs[nextChunkIndex];
     state->chunks.pop();
     state->phase = chunkOutput.newPhase;
     auto remainingBitCountToStore = chunkOutput.newTapeSize;
@@ -156,9 +187,10 @@ class PostTagHistory::Implementation {
 
 PostTagHistory::PostTagHistory() : implementation_(std::make_shared<Implementation>()) {}
 
-PostTagHistory::EvaluationResult PostTagHistory::evaluate(const PostTagState& init,
+PostTagHistory::EvaluationResult PostTagHistory::evaluate(const NamedRule& rule,
+                                                          const PostTagState& init,
                                                           const uint64_t maxEvents,
-                                                          const std::vector<PostTagState>& checkpoints) const {
-  return implementation_->evaluate(init, maxEvents, checkpoints);
+                                                          const std::vector<PostTagState>& checkpoints) {
+  return implementation_->evaluate(rule, init, maxEvents, checkpoints);
 }
 }  // namespace PostTagSystem

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -15,10 +15,13 @@ class PostTagHistory {
     uint64_t eventCount;
   };
 
+  enum class NamedRule { Post = 0, Rule002211 = 1 };
+
   PostTagHistory();
-  EvaluationResult evaluate(const PostTagState& init,
+  EvaluationResult evaluate(const NamedRule& rule,
+                            const PostTagState& init,
                             uint64_t maxEvents,
-                            const std::vector<PostTagState>& checkpoints = {}) const;
+                            const std::vector<PostTagState>& checkpoints = {});
 
  private:
   class Implementation;

--- a/libPostTagSystem/WolframLanguageAPI.cpp
+++ b/libPostTagSystem/WolframLanguageAPI.cpp
@@ -257,15 +257,16 @@ int initStates(WolframLibraryData libData, mint argc, MArgument* argv, MArgument
 PostTagHistory historyEvaluator_;
 
 int evaluatePostTagSystem(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
-  if (argc != 6) {
+  if (argc != 7) {
     return LIBRARY_FUNCTION_ERROR;
   }
 
   try {
-    const auto inState = getState(libData, MArgument_getInteger(argv[0]), MArgument_getMTensor(argv[1]));
+    const PostTagHistory::NamedRule systemCode = static_cast<PostTagHistory::NamedRule>(MArgument_getInteger(argv[0]));
+    const auto inState = getState(libData, MArgument_getInteger(argv[1]), MArgument_getMTensor(argv[2]));
     const auto checkpoints = getStateVector(
-        libData, MArgument_getMTensor(argv[3]), MArgument_getMTensor(argv[4]), MArgument_getMTensor(argv[5]));
-    const auto outState = historyEvaluator_.evaluate(inState, MArgument_getInteger(argv[2]), checkpoints);
+        libData, MArgument_getMTensor(argv[4]), MArgument_getMTensor(argv[5]), MArgument_getMTensor(argv[6]));
+    const auto outState = historyEvaluator_.evaluate(systemCode, inState, MArgument_getInteger(argv[3]), checkpoints);
     MTensor output;
     putState(libData, outState.finalState, &output, {outState.eventCount});
     MArgument_setMTensor(result, output);


### PR DESCRIPTION
## Changes

* Implements packed system 002211.
* Unpacking will be implemented in a separate PR.

## Comments

* The tape cells in system 002211 can take states `0`, `1` and `2`, that is, they need 2 bits to encode them not one.
* As a result, it's packed a bit sparser, and, in particular, one can do 4 events at a time instead of 8 like in the "Post" system.

## Examples

* Evaluate system "002211":
```wl
In[] := GenerateTagSystemHistory[
  "002211", {0, {0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0}}, 660]
Out[] = <|"EventCount" -> 660, "FinalState" -> {1, {0, 0, 1, 0, 0, 1, 0, 0}}|>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/7)
<!-- Reviewable:end -->
