### PR TITLE
Fix Windows CMake to specific version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,14 +164,10 @@ jobs:
       - run:
           name: Install CMake
           command: |
-            cmakeURL=$(\
-              curl -s https://api.github.com/repos/Kitware/CMake/releases/latest \
-              | grep 'browser_download_url' \
-              | cut -d\" -f4 \
-              | grep win64-x64.zip)
-            curl -L --output cmake-win64-x64.zip $cmakeURL
-            unzip -q cmake-win64-x64.zip
-            cmakeDir=$(dir -1 | findstr -i cmake-*-win64-x64)
+            cmakeURL="https://github.com/Kitware/CMake/releases/download/v3.18.6/cmake-3.18.6-win64-x64.zip"
+            curl -L --output cmake.zip $cmakeURL
+            unzip -q cmake.zip
+            cmakeDir=$(dir -1 | findstr -i cmake-*)
             echo "export PATH=\"$(pwd)/$cmakeDir/bin:$PATH\"" >> $BASH_ENV
 
       - run:


### PR DESCRIPTION
## Changes

* CMake download was broken. This PR fixes it to a specific version (like in *SetReplace*) so that it keeps working in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/8)
<!-- Reviewable:end -->
