### PR TITLE
System 000010111

### DIFF
--- a/Kernel/GenerateTagSystemHistory.m
+++ b/Kernel/GenerateTagSystemHistory.m
@@ -40,7 +40,7 @@ expr : GenerateTagSystemHistory[args___] := ModuleScope[
   result /; !FailureQ[result]
 ];
 
-$systems = <|"Post" -> 0, "002211" -> 1|>;
+$systems = <|"Post" -> 0, "002211" -> 1, "000010111" -> 2|>;
 
 With[{systems = Keys[$systems]},
   FE`Evaluate[FEPrivate`AddSpecialArgCompletion["GenerateTagSystemHistory" -> {systems, 0, 0, 0}]]
@@ -49,7 +49,7 @@ With[{systems = Keys[$systems]},
 $systemPattern = Alternatives @@ Keys[$systems];
 $statePattern = {0 | 1 | 2, {(0 | 1) ...}};
 
-$stepsAtATime = <|"Post" -> 8, "002211" -> 4|>;
+$stepsAtATime = <|"Post" -> 8, "002211" -> 4, "000010111" -> 4|>;
 maxEventCountPattern[system_] := (_Integer ? (0 <= # < 2^63 && Mod[#, $stepsAtATime[system]] == 0 &));
 
 generateTagSystemHistory[system : $systemPattern,

--- a/Kernel/packing.m
+++ b/Kernel/packing.m
@@ -21,7 +21,7 @@ expr : ToPackedTagSystemState[args1___][args2___] := ModuleScope[
   result /; !FailureQ[result]
 ];
 
-$systems = {"Post", "002211"};
+$systems = {"Post", "002211", "000010111"};
 
 With[{systems = $systems},
   FE`Evaluate[FEPrivate`AddSpecialArgCompletion["ToPackedTagSystemState" -> {systems}]]
@@ -47,6 +47,10 @@ toPackedTagSystemState["Post"][unpackedTape_] :=
 toPackedTagSystemState["002211"][unpackedTape : {(0 | 1 | 2 | Verbatim[_]) ...}] := toPackedState[2, 2][unpackedTape];
 toPackedTagSystemState["002211"][unpackedTape_] :=
   throw[Failure["invalidUnpackedTape", <|"tape" -> unpackedTape, "maxCellValue" -> 2|>]];
+
+toPackedTagSystemState["000010111"][unpackedTape : {(0 | 1 | Verbatim[_]) ...}] := toPackedState[1, 1][unpackedTape];
+toPackedTagSystemState["000010111"][unpackedTape_] :=
+  throw[Failure["invalidUnpackedTape", <|"tape" -> unpackedTape, "maxCellValue" -> 1|>]];
 
 toPackedTagSystemState[args1___][args2___] /; (Length[{args1}] =!= 1 || Length[{args2}] =!= 1) :=
   throw[Failure["invalidArgumentCountRange",
@@ -86,6 +90,10 @@ fromPackedTagSystemState["Post"][packedState_] := throw[Failure["invalidStateFor
 fromPackedTagSystemState["002211"][packedState : {0 | 1, {(0 | 1) ...}}] /; Mod[Length[packedState], 2] == 0 :=
   fromPackedState[2, 2][packedState];
 fromPackedTagSystemState["002211"][packedState_] := throw[Failure["invalidStateFormat", <|"init" -> packedState|>]];
+
+fromPackedTagSystemState["000010111"][packedState_ : {0, {(0 | 1) ...}}] := fromPackedState[1, 1][packedState];
+fromPackedTagSystemState["000010111"][packedState : Except[{0, {(0 | 1) ...}}]] :=
+  throw[Failure["invalidStateFormat", <|"init" -> packedState|>]];
 
 fromPackedTagSystemState[args1___][args2___] /; (Length[{args1}] =!= 1 || Length[{args2}] =!= 1) :=
   throw[Failure["invalidArgumentCountRange",

--- a/Tests/GenerateTagSystemHistory.wlt
+++ b/Tests/GenerateTagSystemHistory.wlt
@@ -76,6 +76,16 @@
                                    {0, {0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0}},
                                    656],
           <|"EventCount" -> 656, "FinalState" -> {1, {0, 0, 1, 0, 0, 0, 0, 0, 0, 0}}|>
+        ],
+
+        VerificationTest[
+          GenerateTagSystemHistory["000010111", {0, IntegerDigits[716, 2, 10]}, 10^9],
+          <|"EventCount" -> 100280, "FinalState" -> {0, {0, 0, 0, 0, 0, 0}}|>
+        ],
+
+        VerificationTest[
+          GenerateTagSystemHistory["000010111", {0, IntegerDigits[345, 2, 9]}, 10^9],
+          <|"EventCount" -> 26760, "FinalState" -> {0, {0, 0, 0, 0, 0, 0, 0}}|>
         ]
       }]
     }

--- a/Tests/packing.wlt
+++ b/Tests/packing.wlt
@@ -41,7 +41,10 @@
       testUnevaluated[
         FromPackedTagSystemState["002211", 2][{0, {1}}], FromPackedTagSystemState::invalidArgumentCountRange],
       testUnevaluated[
-        FromPackedTagSystemState["002211"][{0, {1}}, 4], FromPackedTagSystemState::invalidArgumentCountRange]
+        FromPackedTagSystemState["002211"][{0, {1}}, 4], FromPackedTagSystemState::invalidArgumentCountRange],
+
+      VerificationTest[ToPackedTagSystemState["000010111"][{0, 0, 1, 0, 1}], {0, {0, 0, 1, 0, 1}}],
+      VerificationTest[FromPackedTagSystemState["000010111"][{0, {0, 0, 1, 0, 1}}], {0, 0, 1, 0, 1}]
     }
   |>
 |>

--- a/libPostTagSystem/PostTagHistory.cpp
+++ b/libPostTagSystem/PostTagHistory.cpp
@@ -27,7 +27,7 @@ class PostTagHistory::Implementation {
   };
 
   struct ChunkedRule {
-    uint8_t tapeAtomLength;
+    uint8_t inputLength;
     uint8_t phaseCount;
     std::vector<uint8_t> outputTapes;
     std::vector<uint8_t> outputLengths;
@@ -38,7 +38,8 @@ class PostTagHistory::Implementation {
 
   const std::unordered_map<NamedRule, ChunkedRule> rules{
       {NamedRule::Post, {1, 3, {0, 0, 0, 3, 0, 1}, {1, 0, 1, 2, 1, 1}, {2, 0, 1, 1, 2, 0}}},
-      {NamedRule::Rule002211, {2, 2, {0, 0, 0, 2, 9, 1, 0, 0}, {1, 0, 1, 1, 2, 1, 0, 0}, {1, 0, 0, 1, 1, 0, 0, 0}}}};
+      {NamedRule::Rule002211, {2, 2, {0, 0, 0, 2, 9, 1, 0, 0}, {2, 0, 2, 2, 4, 2, 0, 0}, {1, 0, 0, 1, 1, 0, 0, 0}}},
+      {NamedRule::Rule000010111, {2, 1, {0, 0, 5, 3}, {1, 3, 3, 3}, {0, 0, 0, 0}}}};
 
   struct ChunkEvaluationTable {
     std::vector<ChunkOutput> outputs;
@@ -80,7 +81,7 @@ class PostTagHistory::Implementation {
 
   ChunkEvaluationTable createChunkEvaluationTable(const ChunkedRule& rule) {
     ChunkEvaluationTable table;
-    table.eventsAtOnce = 8 / rule.tapeAtomLength;
+    table.eventsAtOnce = 8 / rule.inputLength;
     table.phaseCount = rule.phaseCount;
     table.outputs.resize(rule.chunkCount());
     uint8_t inputTape = std::numeric_limits<uint8_t>::max();
@@ -98,12 +99,12 @@ class PostTagHistory::Implementation {
     uint8_t outputSize = 0;
     auto phase = inputPhase;
     auto shiftedInputTape = inputTape;
-    for (uint8_t i = 0; i < 8; i += rule.tapeAtomLength) {
-      uint8_t poppedBits = (shiftedInputTape >> (8 - rule.tapeAtomLength)) & (255 >> (8 - rule.tapeAtomLength));
-      shiftedInputTape <<= rule.tapeAtomLength;
+    for (uint8_t i = 0; i < 8; i += rule.inputLength) {
+      uint8_t poppedBits = (shiftedInputTape >> (8 - rule.inputLength)) & (255 >> (8 - rule.inputLength));
+      shiftedInputTape <<= rule.inputLength;
       uint8_t outputIndex = rule.phaseCount * poppedBits + phase;
-      outputSize += rule.outputLengths[outputIndex] * rule.tapeAtomLength;
-      output = (output << (rule.outputLengths[outputIndex] * rule.tapeAtomLength)) + rule.outputTapes[outputIndex];
+      outputSize += rule.outputLengths[outputIndex];
+      output = (output << (rule.outputLengths[outputIndex])) + rule.outputTapes[outputIndex];
       phase = rule.outputPhases[outputIndex];
     }
     return {output, outputSize, phase};

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -15,7 +15,7 @@ class PostTagHistory {
     uint64_t eventCount;
   };
 
-  enum class NamedRule { Post = 0, Rule002211 = 1 };
+  enum class NamedRule { Post = 0, Rule002211 = 1, Rule000010111 = 2 };
 
   PostTagHistory();
   EvaluationResult evaluate(const NamedRule& rule,


### PR DESCRIPTION
## Changes

* Adds implementation of `{{0, 0} -> {0}, {1, 0} -> {1, 0, 1}, {0, 1} -> {0, 0, 0}, {1, 1} -> {0, 1, 1}}` (system 000010111).
* Unlike previous rules, it reads multiple non-aligned digits from the tape at once.

## Examples

* Reproduce the evolution of a terminating system:
```wl
In[] := GenerateTagSystemHistory["000010111", {0, IntegerDigits[716, 2, 10]}, 10^9]
Out[] = <|"EventCount" -> 100280, "FinalState" -> {0, {0, 0, 0, 0, 0, 0}}|>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/10)
<!-- Reviewable:end -->
