### PR TITLE
MaxTapeLength

### DIFF
--- a/Kernel/GenerateTagSystemHistory.m
+++ b/Kernel/GenerateTagSystemHistory.m
@@ -64,7 +64,9 @@ generateTagSystemHistory[system : $systemPattern,
                                         First /@ checkpoints,
                                         Length /@ Last /@ checkpoints,
                                         Catenate[Last /@ checkpoints]];
-  <|"EventCount" -> First[cppOutput], "FinalState" -> Through[{#[[2]] &, #[[3 ;; ]] &}[cppOutput]]|>
+  <|"EventCount" -> cppOutput[[1]],
+    "MaxTapeLength" -> cppOutput[[2]],
+    "FinalState" -> Through[{#[[3]] &, #[[4 ;; ]] &}[cppOutput]]|>
 ];
 
 generateTagSystemHistory[

--- a/Kernel/cpp.m
+++ b/Kernel/cpp.m
@@ -109,6 +109,6 @@ $libraryFunctions = {
        {Integer, 1},  (* checkpoint heads *)
        {Integer, 1},  (* checkpoint lengths *)
        {Integer, 1}}, (* catenated checkpoint tapes *)
-      {Integer, 1}],  (* {eventCount, headState, tape[[1]], tape[[2]], ...} *)
+      {Integer, 1}],  (* {eventCount, maxTapeLength, headState, tape[[1]], tape[[2]], ...} *)
     $Failed]
 };

--- a/Tests/GenerateTagSystemHistory.wlt
+++ b/Tests/GenerateTagSystemHistory.wlt
@@ -31,19 +31,25 @@
                         {GenerateTagSystemHistory::invalidCheckpoints}] & /@ {0, {0, 0}, {{0, nineZeros}, 0}},
 
         VerificationTest[GenerateTagSystemHistory["Post", {0, {0, 0, 0, 0, 0, 0, 0, 0, 0}}, 8],
-                         <|"EventCount" -> 8, "FinalState" -> {1, {0, 0, 0, 0, 0, 0, 0}}|>],
-        VerificationTest[GenerateTagSystemHistory["Post", {2, {1, 1, 1, 1, 1, 1, 1, 1, 1}}, 8],
-                         <|"EventCount" -> 8, "FinalState" -> {1, {1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1}}|>],
-        VerificationTest[GenerateTagSystemHistory["Post", {0, {}}, 8], <|"EventCount" -> 0, "FinalState" -> {0, {}}|>],
+                         <|"EventCount" -> 8, "MaxTapeLength" -> 9, "FinalState" -> {1, {0, 0, 0, 0, 0, 0, 0}}|>],
+        VerificationTest[
+          GenerateTagSystemHistory["Post", {2, {1, 1, 1, 1, 1, 1, 1, 1, 1}}, 8],
+          <|"EventCount" -> 8, "MaxTapeLength" -> 12, "FinalState" -> {1, {1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1}}|>],
+        VerificationTest[GenerateTagSystemHistory["Post", {0, {}}, 8],
+                         <|"EventCount" -> 0, "MaxTapeLength" -> 0, "FinalState" -> {0, {}}|>],
         VerificationTest[GenerateTagSystemHistory["Post", {0, {0}}, 8],
-                         <|"EventCount" -> 0, "FinalState" -> {0, {0}}|>],
+                         <|"EventCount" -> 0, "MaxTapeLength" -> 1, "FinalState" -> {0, {0}}|>],
         VerificationTest[GenerateTagSystemHistory["Post", {0, nineZeros}, 0],
-                         <|"EventCount" -> 0, "FinalState" -> {0, nineZeros}|>],
+                         <|"EventCount" -> 0, "MaxTapeLength" -> 9, "FinalState" -> {0, nineZeros}|>],
 
         VerificationTest[GenerateTagSystemHistory["Post", {0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, 20858040],
-                         <|"EventCount" -> 20858040, "FinalState" -> {2, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}|>],
+                         <|"EventCount" -> 20858040,
+                           "MaxTapeLength" -> 6783,
+                           "FinalState" -> {2, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}|>],
         VerificationTest[GenerateTagSystemHistory["Post", {0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, #],
-                         <|"EventCount" -> 20858048, "FinalState" -> {0, {0, 0, 0, 0, 0, 0, 0}}|>] & /@
+                         <|"EventCount" -> 20858048,
+                           "MaxTapeLength" -> 6783,
+                           "FinalState" -> {0, {0, 0, 0, 0, 0, 0, 0}}|>] & /@
           {20858048, 20858048 + 8, 2^32 - 8, 2^63 - 8},
 
         VerificationTest[GenerateTagSystemHistory["Post",
@@ -51,6 +57,7 @@
                                                   208570000,
                                                   {2, {0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0}}],
                          <|"EventCount" -> 20858000,
+                           "MaxTapeLength" -> 6783,
                            "FinalState" -> {2, {0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0}}|>],
         VerificationTest[
           GenerateTagSystemHistory["Post",
@@ -60,6 +67,7 @@
                                     {1, {1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1,
                                          1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1}}}],
           <|"EventCount" -> 20857000,
+            "MaxTapeLength" -> 6783,
             "FinalState" -> {1, {1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1,
                                  0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1}}|>],
 
@@ -68,6 +76,7 @@
                                    {0, {0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0}},
                                    600],
           <|"EventCount" -> 600,
+            "MaxTapeLength" -> 40,
             "FinalState" -> {1, {1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1}}|>
         ],
 
@@ -75,17 +84,27 @@
           GenerateTagSystemHistory["002211",
                                    {0, {0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0}},
                                    656],
-          <|"EventCount" -> 656, "FinalState" -> {1, {0, 0, 1, 0, 0, 0, 0, 0, 0, 0}}|>
+          <|"EventCount" -> 656, "MaxTapeLength" -> 40, "FinalState" -> {1, {0, 0, 1, 0, 0, 0, 0, 0, 0, 0}}|>
         ],
 
         VerificationTest[
           GenerateTagSystemHistory["000010111", {0, IntegerDigits[716, 2, 10]}, 10^9],
-          <|"EventCount" -> 100280, "FinalState" -> {0, {0, 0, 0, 0, 0, 0}}|>
+          <|"EventCount" -> 100280, "MaxTapeLength" -> 992, "FinalState" -> {0, {0, 0, 0, 0, 0, 0}}|>
         ],
 
         VerificationTest[
           GenerateTagSystemHistory["000010111", {0, IntegerDigits[345, 2, 9]}, 10^9],
-          <|"EventCount" -> 26760, "FinalState" -> {0, {0, 0, 0, 0, 0, 0, 0}}|>
+          <|"EventCount" -> 26760, "MaxTapeLength" -> 557, "FinalState" -> {0, {0, 0, 0, 0, 0, 0, 0}}|>
+        ],
+
+        VerificationTest[
+          GenerateTagSystemHistory["Post", {0, {1, 1, 1, 1, 1, 1, 1, 1, 1}}, 88]["MaxTapeLength"],
+          20
+        ],
+
+        VerificationTest[
+          GenerateTagSystemHistory["Post", {0, {1, 1, 1, 1, 1, 1, 1, 1, 1}}, 96]["MaxTapeLength"],
+          20
         ]
       }]
     }

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -13,6 +13,7 @@ class PostTagHistory {
   struct EvaluationResult {
     PostTagState finalState;
     uint64_t eventCount;
+    uint64_t maxTapeLength;
   };
 
   enum class NamedRule { Post = 0, Rule002211 = 1, Rule000010111 = 2 };

--- a/libPostTagSystem/WolframLanguageAPI.cpp
+++ b/libPostTagSystem/WolframLanguageAPI.cpp
@@ -268,7 +268,7 @@ int evaluatePostTagSystem(WolframLibraryData libData, mint argc, MArgument* argv
         libData, MArgument_getMTensor(argv[4]), MArgument_getMTensor(argv[5]), MArgument_getMTensor(argv[6]));
     const auto outState = historyEvaluator_.evaluate(systemCode, inState, MArgument_getInteger(argv[3]), checkpoints);
     MTensor output;
-    putState(libData, outState.finalState, &output, {outState.eventCount});
+    putState(libData, outState.finalState, &output, {outState.eventCount, outState.maxTapeLength});
     MArgument_setMTensor(result, output);
   } catch (...) {
     return LIBRARY_FUNCTION_ERROR;


### PR DESCRIPTION
## Changes

* Adds `"MaxTapeLength"` to the output association produced by `Generate(Post)TagSystemHistory`.
* This keep tracks of the length of the tape, and returns the maximum encountered during the evolution.

## Comments

Note, the tape length is computed for the compressed binary representation while running the bit-packed algorithm. That means:

* Superfluous values are ignored (i.e., the values that would not be used in the input). So, the lengths in the original system would be multiplied by the phase count.
* If the system has more than two tape states, the `"MaxTapeLength"` will be larger because it needs to get converted to the binary representation. So, it needs to be divided by `Ceiling[Log2[tapeStateCount]]`.
* Since the tape is evaluated `8 / tapeStateCount` steps at-a-time, the intermediate tape lengths might be skipped. The answer is guaranteed to be within ~8 from the correct answer.

## Examples

* Obtain the max tape lengths during the evaluation of the Post system:

```wl
In[] := GenerateTagSystemHistory["Post", {0, {0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}}, 20858048]
Out[] = <|"EventCount" -> 20858048, "MaxTapeLength" -> 6783, "FinalState" -> {0, {0, 0, 0, 0, 0, 0, 0}}|>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/11)
<!-- Reviewable:end -->
