### PR TITLE
PowerOfTwoEventCounts checkpoints

### DIFF
--- a/Kernel/GenerateTagSystemHistory.m
+++ b/Kernel/GenerateTagSystemHistory.m
@@ -12,6 +12,8 @@ system$ starting from a state with head initPhase$ and tape initTape$ for at mos
 an association containing information about that evolution.
 GeneratePostTagSystemHistory[system$, init$, maxEventCount$, checkpointList$] terminates the evolution once any of the \
 states from checkpointList$ is reached. The states in checkpointList$ are specified using the same format as init$.
+\"PowerOfTwo\" can be used as a special value to automatically create checkpoints from states \
+{0, 1, 2, 4, $$, 2$$k, $$}.
 If the system reaches a state with <= 8 bits of tape cells before maxEventCount$ is reached, that state is returned \
 instead.
 ";
@@ -42,8 +44,12 @@ expr : GenerateTagSystemHistory[args___] := ModuleScope[
 
 $systems = <|"Post" -> 0, "002211" -> 1, "000010111" -> 2|>;
 
-With[{systems = Keys[$systems]},
-  FE`Evaluate[FEPrivate`AddSpecialArgCompletion["GenerateTagSystemHistory" -> {systems, 0, 0, 0}]]
+$checkpointSpecSpecialValues = {"PowerOfTwoEventCounts"};
+
+With[{
+    systems = Keys[$systems],
+    checkpointStrings = $checkpointSpecSpecialValues},
+  FE`Evaluate[FEPrivate`AddSpecialArgCompletion["GenerateTagSystemHistory" -> {systems, 0, 0, checkpointStrings}]]
 ];
 
 $systemPattern = Alternatives @@ Keys[$systems];
@@ -52,18 +58,32 @@ $statePattern = {0 | 1 | 2, {(0 | 1) ...}};
 $stepsAtATime = <|"Post" -> 8, "002211" -> 4, "000010111" -> 4|>;
 maxEventCountPattern[system_] := (_Integer ? (0 <= # < 2^63 && Mod[#, $stepsAtATime[system]] == 0 &));
 
+$checkpointSpecPattern = {($statePattern | Alternatives @@ $checkpointSpecSpecialValues) ...};
+
+parseCheckpointSpec[spec_] := ModuleScope[
+  statesOnly = DeleteCases[spec, _String];
+  {
+    First /@ statesOnly,
+    Length /@ Last /@ statesOnly,
+    Catenate[Last /@ statesOnly],
+    Boole /@ (MemberQ[spec, #] &) /@ $checkpointSpecSpecialValues
+  }
+];
+
 generateTagSystemHistory[system : $systemPattern,
                          {initHead : 0 | 1 | 2, initTape : {(0 | 1) ...}},
                          maxEventCount_,
-                         checkpoints : {$statePattern ...} : {}] /;
+                         checkpointSpec : $checkpointSpecPattern : {}] /;
     MatchQ[maxEventCount, maxEventCountPattern[system]] := ModuleScope[
+  {checkpointHeads, checkpointLengths, checkpointTapes, checkpointFlags} = parseCheckpointSpec[checkpointSpec];
   cppOutput = cpp$evaluatePostTagSystem[$systems[system],
                                         initHead,
                                         initTape,
                                         maxEventCount,
-                                        First /@ checkpoints,
-                                        Length /@ Last /@ checkpoints,
-                                        Catenate[Last /@ checkpoints]];
+                                        checkpointHeads,
+                                        checkpointLengths,
+                                        checkpointTapes,
+                                        checkpointFlags];
   <|"EventCount" -> cppOutput[[1]],
     "MaxTapeLength" -> cppOutput[[2]],
     "FinalState" -> Through[{#[[3]] &, #[[4 ;; ]] &}[cppOutput]]|>

--- a/Kernel/GenerateTagSystemHistory.m
+++ b/Kernel/GenerateTagSystemHistory.m
@@ -13,7 +13,7 @@ an association containing information about that evolution.
 GeneratePostTagSystemHistory[system$, init$, maxEventCount$, checkpointList$] terminates the evolution once any of the \
 states from checkpointList$ is reached. The states in checkpointList$ are specified using the same format as init$.
 \"PowerOfTwo\" can be used as a special value to automatically create checkpoints from states \
-{0, 1, 2, 4, $$, 2$$k, $$}.
+{0, 1, 2, 4, $$, 2^k, $$}.
 If the system reaches a state with <= 8 bits of tape cells before maxEventCount$ is reached, that state is returned \
 instead.
 ";

--- a/Kernel/cpp.m
+++ b/Kernel/cpp.m
@@ -108,7 +108,8 @@ $libraryFunctions = {
        Integer,       (* event count *)
        {Integer, 1},  (* checkpoint heads *)
        {Integer, 1},  (* checkpoint lengths *)
-       {Integer, 1}}, (* catenated checkpoint tapes *)
+       {Integer, 1},  (* catenated checkpoint tapes *)
+       {Integer, 1}}, (* special checkpoint flags *)
       {Integer, 1}],  (* {eventCount, maxTapeLength, headState, tape[[1]], tape[[2]], ...} *)
     $Failed]
 };

--- a/Tests/GenerateTagSystemHistory.wlt
+++ b/Tests/GenerateTagSystemHistory.wlt
@@ -105,6 +105,40 @@
         VerificationTest[
           GenerateTagSystemHistory["Post", {0, {1, 1, 1, 1, 1, 1, 1, 1, 1}}, 96]["MaxTapeLength"],
           20
+        ],
+
+        VerificationTest[
+          GenerateTagSystemHistory["Post", {1, {1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1}}, 128, {"PowerOfTwoEventCounts"}][[
+            {"EventCount", "FinalState"}]],
+          <|"EventCount" -> 40, "FinalState" -> {1, {1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1}}|>
+        ],
+
+        VerificationTest[
+          GenerateTagSystemHistory["Post", {1, {1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1}}, 128, {}]["EventCount"],
+          128
+        ],
+
+        VerificationTest[
+          GenerateTagSystemHistory["Post", {0, {0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1}}, 128, {"PowerOfTwoEventCounts"}][
+            "EventCount"],
+          48
+        ],
+
+        VerificationTest[
+          GenerateTagSystemHistory["Post", {2, {0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 1, 0}}, 128, {"PowerOfTwoEventCounts"}][[
+            {"EventCount", "FinalState"}]],
+          <|"EventCount" -> 88,
+            "FinalState" -> GenerateTagSystemHistory[
+              "Post", {2, {0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 1, 0}}, 64, {"PowerOfTwoEventCounts"}]["FinalState"]|>
+        ],
+
+        VerificationTest[
+          Max @ BlockRandom[
+            Table[
+              GenerateTagSystemHistory[
+                "Post", {RandomInteger[2], RandomInteger[1, 32]}, 10^12, {"PowerOfTwoEventCounts"}],
+              1000]
+          , RandomSeeding -> 0][[All, "EventCount"]] < 10^12
         ]
       }]
     }

--- a/libPostTagSystem/PostTagHistory.cpp
+++ b/libPostTagSystem/PostTagHistory.cpp
@@ -55,15 +55,15 @@ class PostTagHistory::Implementation {
   EvaluationResult evaluate(const NamedRule& rule,
                             const PostTagState& init,
                             const uint64_t maxEvents,
-                            const std::vector<PostTagState>& checkpoints) {
+                            const CheckpointSpec& checkpointSpec) {
     const ChunkEvaluationTable chunkEvaluationTable = createChunkEvaluationTable(rule);
     if (maxEvents % chunkEvaluationTable.eventsAtOnce != 0) {
       return {{{}, std::numeric_limits<uint8_t>::max()}, 0, 0};
     }
     auto chunkedState = toChunkedState(init);
     std::vector<ChunkedState> chunkedCheckpoints;
-    chunkedCheckpoints.reserve(checkpoints.size());
-    for (const auto& checkpoint : checkpoints) {
+    chunkedCheckpoints.reserve(checkpointSpec.states.size());
+    for (const auto& checkpoint : checkpointSpec.states) {
       chunkedCheckpoints.push_back(toChunkedState(checkpoint));
     }
     uint64_t maxTapeLength = tapeLength(chunkedState);
@@ -199,7 +199,7 @@ PostTagHistory::PostTagHistory() : implementation_(std::make_shared<Implementati
 PostTagHistory::EvaluationResult PostTagHistory::evaluate(const NamedRule& rule,
                                                           const PostTagState& init,
                                                           const uint64_t maxEvents,
-                                                          const std::vector<PostTagState>& checkpoints) {
+                                                          const CheckpointSpec& checkpoints) {
   return implementation_->evaluate(rule, init, maxEvents, checkpoints);
 }
 }  // namespace PostTagSystem

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -18,9 +18,13 @@ class PostTagHistory {
 
   enum class NamedRule { Post = 0, Rule002211 = 1, Rule000010111 = 2 };
 
+  struct CheckpointSpecFlags {
+    bool powerOfTwoEventCounts;
+  };
+
   struct CheckpointSpec {
     std::vector<PostTagState> states;
-    bool powerOfTwoEventCounts;
+    CheckpointSpecFlags flags;
   };
 
   PostTagHistory();

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -18,11 +18,16 @@ class PostTagHistory {
 
   enum class NamedRule { Post = 0, Rule002211 = 1, Rule000010111 = 2 };
 
+  struct CheckpointSpec {
+    std::vector<PostTagState> states;
+    bool powerOfTwoEventCounts;
+  };
+
   PostTagHistory();
   EvaluationResult evaluate(const NamedRule& rule,
                             const PostTagState& init,
                             uint64_t maxEvents,
-                            const std::vector<PostTagState>& checkpoints = {});
+                            const CheckpointSpec& checkpointSpec = CheckpointSpec());
 
  private:
   class Implementation;

--- a/libPostTagSystem/WolframLanguageAPI.cpp
+++ b/libPostTagSystem/WolframLanguageAPI.cpp
@@ -266,7 +266,8 @@ int evaluatePostTagSystem(WolframLibraryData libData, mint argc, MArgument* argv
     const auto inState = getState(libData, MArgument_getInteger(argv[1]), MArgument_getMTensor(argv[2]));
     const auto checkpoints = getStateVector(
         libData, MArgument_getMTensor(argv[4]), MArgument_getMTensor(argv[5]), MArgument_getMTensor(argv[6]));
-    const auto outState = historyEvaluator_.evaluate(systemCode, inState, MArgument_getInteger(argv[3]), checkpoints);
+    const auto outState =
+        historyEvaluator_.evaluate(systemCode, inState, MArgument_getInteger(argv[3]), {checkpoints, false});
     MTensor output;
     putState(libData, outState.finalState, &output, {outState.eventCount, outState.maxTapeLength});
     MArgument_setMTensor(result, output);

--- a/libPostTagSystem/test/PostTagSystem_test.cpp
+++ b/libPostTagSystem/test/PostTagSystem_test.cpp
@@ -36,8 +36,8 @@ TEST(PostTagHistory, checkpoints) {
   const PostTagState init = {{0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0}, 0};
   constexpr uint64_t lateCheckpointEventCount = 20858000;
   const PostTagState lateCheckpoint = {{0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0}, 2};
-  const auto lateEvaluationResult =
-      history.evaluate(PostTagHistory::NamedRule::Post, init, 10 * lateCheckpointEventCount, {lateCheckpoint});
+  const auto lateEvaluationResult = history.evaluate(
+      PostTagHistory::NamedRule::Post, init, 10 * lateCheckpointEventCount, {{lateCheckpoint}, {false}});
   ASSERT_EQ(lateEvaluationResult.eventCount, lateCheckpointEventCount);
   ASSERT_EQ(lateEvaluationResult.finalState.headState, lateCheckpoint.headState);
   ASSERT_EQ(lateEvaluationResult.finalState.tape, lateCheckpoint.tape);
@@ -46,8 +46,10 @@ TEST(PostTagHistory, checkpoints) {
   const PostTagState earlyCheckpoint = {{1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1,
                                          1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1},
                                         1};
-  const auto earlyEvaluationResult = history.evaluate(
-      PostTagHistory::NamedRule::Post, init, 10 * lateCheckpointEventCount, {lateCheckpoint, earlyCheckpoint});
+  const auto earlyEvaluationResult = history.evaluate(PostTagHistory::NamedRule::Post,
+                                                      init,
+                                                      10 * lateCheckpointEventCount,
+                                                      {{lateCheckpoint, earlyCheckpoint}, {false}});
   ASSERT_EQ(earlyEvaluationResult.eventCount, earlyCheckpointEventCount);
   ASSERT_EQ(earlyEvaluationResult.finalState.headState, earlyCheckpoint.headState);
   ASSERT_EQ(earlyEvaluationResult.finalState.tape, earlyCheckpoint.tape);


### PR DESCRIPTION
## Changes

* Allows one to specify a special value `"PowerOfTwoEventCounts"` as a checkpoint.
* This will automatically create checkpoints at 0, 1, 2, 4, 8, ..., 2^k, ... events.

## Comments

* Assuming that Post tag system always terminates or reaches a cycle, this will guarantee that `GenerateTagSystemHistory` will always terminate even if the number of events is very large (infinity).

## Examples

* Consider a system that ends with a cycle (so, does not terminate):

```wl
In[] := GenerateTagSystemHistory["Post", {2, {0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 1, 0}}, 1024, {}]
Out[] = <|"EventCount" -> 1024,
          "MaxTapeLength" -> 13,
          "FinalState" -> {1, {1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1}}|>
```

* One can now automatically evaluate it until the cycle is reached. The following creates the checkpoints at events 0, 1, 2, 4, 8, 16, 32 and 64, and it hits the 64-checkpoints again at step 88:

```wl
In[] := GenerateTagSystemHistory[
  "Post", {2, {0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 1, 0}}, 1024, {"PowerOfTwoEventCounts"}]
Out[] = <|"EventCount" -> 88,
          "MaxTapeLength" -> 13,
          "FinalState" -> {1, {1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1}}|>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/12)
<!-- Reviewable:end -->
