### PR TITLE
Remove Markdown and bash formatting from lint.sh

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -76,22 +76,6 @@ for file in "${cppFiles[@]}"; do
   formatWithCommand clang-format "$file"
 done
 
-for file in "${bashFiles[@]}"; do
-  if [ $formatInPlace -eq 1 ]; then
-    shfmt -w -i 2 "$file"
-  else
-    shfmt -l -d -i 2 "$file" || exitStatus=1
-  fi
-done
-
-for file in "${markdownFiles[@]}"; do
-  if [ $formatInPlace -eq 1 ]; then
-    markdownlint -f "$file" || :
-  else
-    markdownlint "$file" || exitStatus=1
-  fi
-done
-
 for file in "${remainingFiles[@]}"; do
   formatWithCommand ./scripts/whitespaceFormat.sh "$file"
 done
@@ -104,10 +88,6 @@ fi
 
 for file in "${cppFiles[@]}"; do
   cpplint --quiet --extensions=hpp,cpp "$file" || exitStatus=1
-done
-
-for file in "${bashFiles[@]}"; do
-  shellcheck "$file" || exitStatus=1
 done
 
 widthLimit=120


### PR DESCRIPTION
## Changes

* Removes Markdown and bash linting from `lint.sh`.

## Comments

* The correct solution would be to add flags to disable/enable them (or, better yet, only lint modified files in the hook), however, that solution should be implemented in *SetReplace* instead (and then copied here). This PR is just a quick fix for the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/15)
<!-- Reviewable:end -->
