### PR TITLE
Max tape length limit

### DIFF
--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -42,7 +42,7 @@ class PostTagHistory {
     uint64_t maxTimeNs = std::numeric_limits<uint64_t>::max();
 
     EvaluationLimits() = default;
-    EvaluationLimits(uint64_t maxEventCountInput) : maxEventCount(maxEventCountInput) {}
+    explicit EvaluationLimits(uint64_t maxEventCountInput) : maxEventCount(maxEventCountInput) {}
   };
 
   PostTagHistory();

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -10,13 +10,19 @@
 namespace PostTagSystem {
 class PostTagHistory {
  public:
-  enum class ConclusionReason { InvalidInput, Terminated, ReachedCheckpoint, MaxEventCountExceeded };
+  enum class ConclusionReason {
+    InvalidInput,
+    Terminated,
+    ReachedCheckpoint,
+    MaxEventCountExceeded,
+    MaxTapeLengthExceeded
+  };
 
   struct EvaluationResult {
     ConclusionReason conclusionReason;
     TagState finalState;
     uint64_t eventCount;
-    uint64_t maxTapeLength;
+    uint64_t maxIntermediateTapeLength;
   };
 
   enum class NamedRule { Post = 0, Rule002211 = 1, Rule000010111 = 2 };
@@ -30,10 +36,19 @@ class PostTagHistory {
     CheckpointSpecFlags flags;
   };
 
+  struct EvaluationLimits {
+    uint64_t maxEventCount = std::numeric_limits<uint64_t>::max() - 7;
+    uint64_t maxTapeLength = std::numeric_limits<uint64_t>::max();
+    uint64_t maxTimeNs = std::numeric_limits<uint64_t>::max();
+
+    EvaluationLimits() = default;
+    EvaluationLimits(uint64_t maxEventCountInput) : maxEventCount(maxEventCountInput) {}
+  };
+
   PostTagHistory();
   EvaluationResult evaluate(const NamedRule& rule,
                             const TagState& init,
-                            uint64_t maxEvents,
+                            const EvaluationLimits& limits,
                             const CheckpointSpec& checkpointSpec = CheckpointSpec());
 
  private:

--- a/libPostTagSystem/PostTagSearcher.cpp
+++ b/libPostTagSystem/PostTagSearcher.cpp
@@ -36,19 +36,20 @@ class PostTagSearcher::Implementation {
 
   std::vector<EvaluationResult> evaluateGroup(const std::vector<TagState>& states,
                                               const EvaluationParameters& parameters) {
-    // TODO(maxitg): Implement maxTapeLength parameters
     // TODO(maxitg): Implement groupTimeConstraintNs parameter
     // TODO(maxitg): Implement checkpoints parameter
 
     std::vector<EvaluationResult> results;
     results.reserve(states.size());
     PostTagHistory evaluator;
+    PostTagHistory::EvaluationLimits limits;
+    limits.maxEventCount = parameters.maxEventCount;
+    limits.maxTapeLength = parameters.maxTapeLength;
     for (const auto& init : states) {
-      const auto singleInitResult =
-          evaluator.evaluate(PostTagHistory::NamedRule::Post, init, parameters.maxEventCount, {{}, {true}});
+      const auto singleInitResult = evaluator.evaluate(PostTagHistory::NamedRule::Post, init, limits, {{}, {true}});
       EvaluationResult result;
       result.eventCount = singleInitResult.eventCount;
-      result.maxTapeLength = singleInitResult.maxTapeLength;
+      result.maxTapeLength = singleInitResult.maxIntermediateTapeLength;
       result.finalTapeLength = singleInitResult.finalState.tape.size();
       result.initialState = init;
       result.finalState = singleInitResult.finalState;

--- a/libPostTagSystem/WolframLanguageAPI.cpp
+++ b/libPostTagSystem/WolframLanguageAPI.cpp
@@ -270,10 +270,12 @@ int evaluatePostTagSystem(WolframLibraryData libData, mint argc, MArgument* argv
     const auto checkpoints = getStateVector(
         libData, MArgument_getMTensor(argv[4]), MArgument_getMTensor(argv[5]), MArgument_getMTensor(argv[6]));
     const auto checkpointFlags = getCheckpointFlags(libData, MArgument_getMTensor(argv[7]));
-    const auto outState =
-        historyEvaluator_.evaluate(systemCode, inState, MArgument_getInteger(argv[3]), {checkpoints, checkpointFlags});
+    const auto outState = historyEvaluator_.evaluate(systemCode,
+                                                     inState,
+                                                     PostTagHistory::EvaluationLimits(MArgument_getInteger(argv[3])),
+                                                     {checkpoints, checkpointFlags});
     MTensor output;
-    putState(libData, outState.finalState, &output, {outState.eventCount, outState.maxTapeLength});
+    putState(libData, outState.finalState, &output, {outState.eventCount, outState.maxIntermediateTapeLength});
     MArgument_setMTensor(result, output);
   } catch (...) {
     return LIBRARY_FUNCTION_ERROR;

--- a/libPostTagSystem/test/PostTagSearcher_test.cpp
+++ b/libPostTagSystem/test/PostTagSearcher_test.cpp
@@ -29,8 +29,8 @@ void compareResults(const TagState& init,
                     const PostTagSearcher::EvaluationResult& result,
                     uint64_t eventLimit = std::numeric_limits<uint64_t>::max() - 7) {
   PostTagHistory singleHistoryEvaluator;
-  const auto singleResult =
-      singleHistoryEvaluator.evaluate(PostTagHistory::NamedRule::Post, init, eventLimit, {{}, {true}});
+  const auto singleResult = singleHistoryEvaluator.evaluate(
+      PostTagHistory::NamedRule::Post, init, PostTagHistory::EvaluationLimits(eventLimit), {{}, {true}});
 
   if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::InvalidInput) {
     ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::InvalidInput);
@@ -44,7 +44,7 @@ void compareResults(const TagState& init,
 
   ASSERT_EQ(result.finalState, singleResult.finalState);
   ASSERT_EQ(result.eventCount, singleResult.eventCount);
-  ASSERT_EQ(result.maxTapeLength, singleResult.maxTapeLength);
+  ASSERT_EQ(result.maxTapeLength, singleResult.maxIntermediateTapeLength);
   ASSERT_EQ(result.finalTapeLength, singleResult.finalState.tape.size());
   ASSERT_EQ(result.initialState, init);
 }


### PR DESCRIPTION
## Changes

* Allows one to terminate the evolution once the max tape length is reached.

## Comments

* `PostTagSearcher` can now use `maxTapeLength` parameters as well.

## Examples

* Evaluate a state up to tape length of 52:
  ```c++
  PostTagHistory::EvaluationLimits limits;
  limits.maxTapeLength = 52;
  const auto& result =
      PostTagHistory().evaluate(PostTagHistory::NamedRule::Post, TagState(20, 123, 0), limits);
  ```
* This returns the evolution result:
  ```prose
  conclusionReason           MaxTapeLengthExceeded
  finalState
    tape	                   54 bits
    headState	           1
  eventCount	           912
  maxIntermediateTapeLength  54
  ```
* Note that the final tape length exceeds the constraint because it terminates on the first 8-step the constraint is exceeded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/19)
<!-- Reviewable:end -->
