### PR TITLE
Searcher checkpoints

### DIFF
--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -13,7 +13,8 @@ class PostTagHistory {
   enum class ConclusionReason {
     InvalidInput,
     Terminated,
-    ReachedCheckpoint,
+    ReachedExplicitCheckpoint,
+    ReachedAutomaticCheckpoint,
     MaxEventCountExceeded,
     MaxTapeLengthExceeded
   };

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -52,6 +52,11 @@ class PostTagHistory {
                             const EvaluationLimits& limits,
                             const CheckpointSpec& checkpointSpec = CheckpointSpec());
 
+  std::vector<EvaluationResult> evaluate(const NamedRule& rule,
+                                         const std::vector<TagState>& inits,
+                                         const EvaluationLimits& limits,
+                                         const CheckpointSpec& checkpointSpec = CheckpointSpec());
+
  private:
   class Implementation;
   std::shared_ptr<Implementation> implementation_;

--- a/libPostTagSystem/PostTagSearcher.cpp
+++ b/libPostTagSystem/PostTagSearcher.cpp
@@ -46,7 +46,7 @@ class PostTagSearcher::Implementation {
     limits.maxTapeLength = parameters.maxTapeLength;
     const auto singleInitResults =
         evaluator.evaluate(PostTagHistory::NamedRule::Post, states, limits, {parameters.checkpoints, {true}});
-    for (int initIndex = 0; initIndex < states.size(); ++initIndex) {
+    for (size_t initIndex = 0; initIndex < states.size(); ++initIndex) {
       EvaluationResult result;
       result.eventCount = singleInitResults[initIndex].eventCount;
       result.maxTapeLength = singleInitResults[initIndex].maxIntermediateTapeLength;

--- a/libPostTagSystem/PostTagSearcher.cpp
+++ b/libPostTagSystem/PostTagSearcher.cpp
@@ -44,15 +44,16 @@ class PostTagSearcher::Implementation {
     PostTagHistory::EvaluationLimits limits;
     limits.maxEventCount = parameters.maxEventCount;
     limits.maxTapeLength = parameters.maxTapeLength;
-    for (const auto& init : states) {
-      const auto singleInitResult = evaluator.evaluate(PostTagHistory::NamedRule::Post, init, limits, {parameters.checkpoints, {true}});
+    const auto singleInitResults =
+        evaluator.evaluate(PostTagHistory::NamedRule::Post, states, limits, {parameters.checkpoints, {true}});
+    for (int initIndex = 0; initIndex < states.size(); ++initIndex) {
       EvaluationResult result;
-      result.eventCount = singleInitResult.eventCount;
-      result.maxTapeLength = singleInitResult.maxIntermediateTapeLength;
-      result.finalTapeLength = singleInitResult.finalState.tape.size();
-      result.initialState = init;
-      result.finalState = singleInitResult.finalState;
-      switch (singleInitResult.conclusionReason) {
+      result.eventCount = singleInitResults[initIndex].eventCount;
+      result.maxTapeLength = singleInitResults[initIndex].maxIntermediateTapeLength;
+      result.finalTapeLength = singleInitResults[initIndex].finalState.tape.size();
+      result.initialState = states[initIndex];
+      result.finalState = singleInitResults[initIndex].finalState;
+      switch (singleInitResults[initIndex].conclusionReason) {
         case PostTagHistory::ConclusionReason::Terminated:
           result.conclusionReason = ConclusionReason::Terminated;
           break;

--- a/libPostTagSystem/PostTagSearcher.cpp
+++ b/libPostTagSystem/PostTagSearcher.cpp
@@ -37,7 +37,6 @@ class PostTagSearcher::Implementation {
   std::vector<EvaluationResult> evaluateGroup(const std::vector<TagState>& states,
                                               const EvaluationParameters& parameters) {
     // TODO(maxitg): Implement groupTimeConstraintNs parameter
-    // TODO(maxitg): Implement checkpoints parameter
 
     std::vector<EvaluationResult> results;
     results.reserve(states.size());
@@ -46,7 +45,7 @@ class PostTagSearcher::Implementation {
     limits.maxEventCount = parameters.maxEventCount;
     limits.maxTapeLength = parameters.maxTapeLength;
     for (const auto& init : states) {
-      const auto singleInitResult = evaluator.evaluate(PostTagHistory::NamedRule::Post, init, limits, {{}, {true}});
+      const auto singleInitResult = evaluator.evaluate(PostTagHistory::NamedRule::Post, init, limits, {parameters.checkpoints, {true}});
       EvaluationResult result;
       result.eventCount = singleInitResult.eventCount;
       result.maxTapeLength = singleInitResult.maxIntermediateTapeLength;
@@ -58,8 +57,12 @@ class PostTagSearcher::Implementation {
           result.conclusionReason = ConclusionReason::Terminated;
           break;
 
-        case PostTagHistory::ConclusionReason::ReachedCheckpoint:
+        case PostTagHistory::ConclusionReason::ReachedAutomaticCheckpoint:
           result.conclusionReason = ConclusionReason::ReachedCycle;
+          break;
+
+        case PostTagHistory::ConclusionReason::ReachedExplicitCheckpoint:
+          result.conclusionReason = ConclusionReason::ReachedKnownCheckpoint;
           break;
 
         case PostTagHistory::ConclusionReason::MaxEventCountExceeded:

--- a/libPostTagSystem/test/PostTagSearcher_test.cpp
+++ b/libPostTagSystem/test/PostTagSearcher_test.cpp
@@ -36,8 +36,10 @@ void compareResults(const TagState& init,
     ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::InvalidInput);
   } else if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::Terminated) {
     ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::Terminated);
-  } else if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::ReachedCheckpoint) {
+  } else if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::ReachedAutomaticCheckpoint) {
     ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::ReachedCycle);
+  } else if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::ReachedExplicitCheckpoint) {
+    ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::ReachedKnownCheckpoint);
   } else if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::MaxEventCountExceeded) {
     ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::MaxEventCountExceeded);
   }


### PR DESCRIPTION
## Changes

* `PostTagSearcher` now uses explicit checkpoints from `EvaluationParameters`.
* The trie from explicit checkpoints is only constructed once and shared across all inputs.
* There is a separate trie for automatic checkpoints which is unique to each input.

## Comments

* We might want to share the automatic checkpoints trie in the future as well, but that will require storing checkpoints source in the trie itself (to distinguish between `"ReachedCycle"` and `"MergedWithAnotherInput"`) conclusions.

## Examples

* The following produces 6 outputs, in which 0th and 3rd reach the provided checkpoint:
```c++
PostTagSearcher::EvaluationParameters parameters;
parameters.checkpoints = {{{0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0}, 2}};
const auto result = PostTagSearcher().evaluateRange(20, 123, 125, parameters);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/21)
<!-- Reviewable:end -->
