### PR TITLE
Time constraint

### DIFF
--- a/libPostTagSystem/PostTagHistory.cpp
+++ b/libPostTagSystem/PostTagHistory.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <limits>
 #include <memory>
 #include <queue>

--- a/libPostTagSystem/PostTagHistory.cpp
+++ b/libPostTagSystem/PostTagHistory.cpp
@@ -187,7 +187,7 @@ class PostTagHistory::Implementation {
     }
     CheckpointsTrie automaticCheckpoints;
     uint64_t eventCount;
-    constexpr int eventsPerClockCheck = 100;
+    constexpr int eventsPerClockCheck = 100000;
     for (eventCount = 0; eventCount < limits.maxEventCount && state->chunks.size() > 1;
          eventCount += evaluationTable.eventsAtOnce) {
       if (eventCount % eventsPerClockCheck == 0 && std::chrono::steady_clock::now() > endClock) {

--- a/libPostTagSystem/PostTagHistory.cpp
+++ b/libPostTagSystem/PostTagHistory.cpp
@@ -58,9 +58,14 @@ class PostTagHistory::Implementation {
                                          const std::vector<TagState>& inits,
                                          const EvaluationLimits& limits,
                                          const CheckpointSpec& checkpointSpec) {
-    constexpr uint64_t nsPerSec = 1000000000;
     const auto startClock = std::chrono::steady_clock::now();
-    const auto endClock = startClock + std::chrono::nanoseconds(limits.maxTimeNs);
+    std::chrono::steady_clock::time_point endClock;
+
+    if (std::chrono::nanoseconds(limits.maxTimeNs) > std::chrono::steady_clock::time_point::max() - startClock) {
+      endClock = std::chrono::steady_clock::time_point::max();
+    } else {
+      endClock = startClock + std::chrono::nanoseconds(limits.maxTimeNs);
+    }
 
     const ChunkEvaluationTable chunkEvaluationTable = createChunkEvaluationTable(rule);
     if (limits.maxEventCount % chunkEvaluationTable.eventsAtOnce != 0) {

--- a/libPostTagSystem/PostTagHistory.cpp
+++ b/libPostTagSystem/PostTagHistory.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <ctime>
 #include <limits>
 #include <memory>
 #include <queue>

--- a/libPostTagSystem/PostTagHistory.cpp
+++ b/libPostTagSystem/PostTagHistory.cpp
@@ -187,7 +187,7 @@ class PostTagHistory::Implementation {
     }
     CheckpointsTrie automaticCheckpoints;
     uint64_t eventCount;
-    constexpr int eventsPerClockCheck = 100000;
+    constexpr int eventsPerClockCheck = 1000;
     for (eventCount = 0; eventCount < limits.maxEventCount && state->chunks.size() > 1;
          eventCount += evaluationTable.eventsAtOnce) {
       if (eventCount % eventsPerClockCheck == 0 && std::chrono::steady_clock::now() > endClock) {

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -43,7 +43,6 @@ class PostTagHistory {
     uint64_t maxEventCount = std::numeric_limits<uint64_t>::max() - 7;
     uint64_t maxTapeLength = std::numeric_limits<uint64_t>::max();
     uint64_t maxTimeNs = std::numeric_limits<uint64_t>::max();
-    clock_t terminationClock = std::numeric_limits<clock_t>::max();
 
     EvaluationLimits() = default;
     explicit EvaluationLimits(uint64_t maxEventCountInput) : maxEventCount(maxEventCountInput) {}

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -16,7 +16,9 @@ class PostTagHistory {
     ReachedExplicitCheckpoint,
     ReachedAutomaticCheckpoint,
     MaxEventCountExceeded,
-    MaxTapeLengthExceeded
+    MaxTapeLengthExceeded,
+    TimeConstraintExceeded,
+    NotEvaluated
   };
 
   struct EvaluationResult {
@@ -41,6 +43,7 @@ class PostTagHistory {
     uint64_t maxEventCount = std::numeric_limits<uint64_t>::max() - 7;
     uint64_t maxTapeLength = std::numeric_limits<uint64_t>::max();
     uint64_t maxTimeNs = std::numeric_limits<uint64_t>::max();
+    clock_t terminationClock = std::numeric_limits<clock_t>::max();
 
     EvaluationLimits() = default;
     explicit EvaluationLimits(uint64_t maxEventCountInput) : maxEventCount(maxEventCountInput) {}

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -42,7 +42,7 @@ class PostTagHistory {
   struct EvaluationLimits {
     uint64_t maxEventCount = std::numeric_limits<uint64_t>::max() - 7;
     uint64_t maxTapeLength = std::numeric_limits<uint64_t>::max();
-    uint64_t maxTimeNs = std::numeric_limits<uint64_t>::max();
+    int64_t maxTimeNs = std::numeric_limits<int64_t>::max();
 
     EvaluationLimits() = default;
     explicit EvaluationLimits(uint64_t maxEventCountInput) : maxEventCount(maxEventCountInput) {}

--- a/libPostTagSystem/PostTagSearcher.cpp
+++ b/libPostTagSystem/PostTagSearcher.cpp
@@ -80,7 +80,9 @@ class PostTagSearcher::Implementation {
         default:
           result.conclusionReason = ConclusionReason::InvalidInput;
       }
-      results.push_back(result);
+      if (result.conclusionReason != ConclusionReason::NotEvaluated || parameters.includeUnevaluatedStates) {
+        results.push_back(result);
+      }
     }
     return results;
   }

--- a/libPostTagSystem/PostTagSearcher.cpp
+++ b/libPostTagSystem/PostTagSearcher.cpp
@@ -36,14 +36,13 @@ class PostTagSearcher::Implementation {
 
   std::vector<EvaluationResult> evaluateGroup(const std::vector<TagState>& states,
                                               const EvaluationParameters& parameters) {
-    // TODO(maxitg): Implement groupTimeConstraintNs parameter
-
     std::vector<EvaluationResult> results;
     results.reserve(states.size());
     PostTagHistory evaluator;
     PostTagHistory::EvaluationLimits limits;
     limits.maxEventCount = parameters.maxEventCount;
     limits.maxTapeLength = parameters.maxTapeLength;
+    limits.maxTimeNs = parameters.groupTimeConstraintNs;
     const auto singleInitResults =
         evaluator.evaluate(PostTagHistory::NamedRule::Post, states, limits, {parameters.checkpoints, {true}});
     for (size_t initIndex = 0; initIndex < states.size(); ++initIndex) {
@@ -68,6 +67,14 @@ class PostTagSearcher::Implementation {
 
         case PostTagHistory::ConclusionReason::MaxEventCountExceeded:
           result.conclusionReason = ConclusionReason::MaxEventCountExceeded;
+          break;
+
+        case PostTagHistory::ConclusionReason::TimeConstraintExceeded:
+          result.conclusionReason = ConclusionReason::TimeConstraintExceeded;
+          break;
+
+        case PostTagHistory::ConclusionReason::NotEvaluated:
+          result.conclusionReason = ConclusionReason::NotEvaluated;
           break;
 
         default:

--- a/libPostTagSystem/PostTagSearcher.hpp
+++ b/libPostTagSystem/PostTagSearcher.hpp
@@ -45,8 +45,9 @@ class PostTagSearcher {
     // If the time constraint is exceeded the current EvaluationResult and all the remaining ones will have
     // TimeConstraintExceeded conclusion reason. The aborted evaluations will have EvaluationResult filled in with
     // values obtained so far. The remaining ones will be filled with zeros.
-    uint64_t groupTimeConstraintNs = std::numeric_limits<uint64_t>::max();
+    int64_t groupTimeConstraintNs = std::numeric_limits<int64_t>::max();
     Checkpoints checkpoints = {};
+    // TODO(maxitg): Add an option to omit returning unevaluated states
   };
 
   // The functions below use two tries. One for the input checkpoints which is shared among all of them. The other trie

--- a/libPostTagSystem/PostTagSearcher.hpp
+++ b/libPostTagSystem/PostTagSearcher.hpp
@@ -47,7 +47,7 @@ class PostTagSearcher {
     // values obtained so far. The remaining ones will be filled with zeros.
     int64_t groupTimeConstraintNs = std::numeric_limits<int64_t>::max();
     Checkpoints checkpoints = {};
-    // TODO(maxitg): Add an option to omit returning unevaluated states
+    bool includeUnevaluatedStates = false;
   };
 
   // The functions below use two tries. One for the input checkpoints which is shared among all of them. The other trie

--- a/libPostTagSystem/test/PostTagSearcher_test.cpp
+++ b/libPostTagSystem/test/PostTagSearcher_test.cpp
@@ -124,15 +124,26 @@ TEST(PostTagSearcher, zeroTimeConstraint) {
   PostTagSearcher searcher;
   PostTagSearcher::EvaluationParameters parameters;
   parameters.groupTimeConstraintNs = 0;
+  parameters.includeUnevaluatedStates = true;
   const auto result = searcher.evaluateRange(20, 123, 124, parameters);
   ASSERT_EQ(result.size(), 3);
   ASSERT_EQ(result[0].conclusionReason, PostTagSearcher::ConclusionReason::NotEvaluated);
+}
+
+TEST(PostTagSearcher, includeUnevaluatedStates) {
+  PostTagSearcher searcher;
+  PostTagSearcher::EvaluationParameters parameters;
+  parameters.groupTimeConstraintNs = 0;
+  parameters.includeUnevaluatedStates = false;
+  const auto result = searcher.evaluateRange(20, 123, 124, parameters);
+  ASSERT_EQ(result.size(), 0);
 }
 
 TEST(PostTagSearcher, smallTimeConstraint) {
   PostTagSearcher searcher;
   PostTagSearcher::EvaluationParameters parameters;
   parameters.groupTimeConstraintNs = 100000000;  // 0.1 seconds
+  parameters.includeUnevaluatedStates = true;
   // The following init takes ~4 seconds to terminate
   const auto result = searcher.evaluateRange(64, 1473593303835332608, 1473593303835332609, parameters);
   ASSERT_EQ(result.size(), 3);

--- a/libPostTagSystem/test/PostTagSearcher_test.cpp
+++ b/libPostTagSystem/test/PostTagSearcher_test.cpp
@@ -119,4 +119,23 @@ TEST(PostTagSearcher, checkpoints) {
   compareResults(TagState(20, 123, 0), result[0], PostTagHistory::EvaluationLimits(), parameters.checkpoints);
   compareResults(TagState(20, 124, 0), result[3], PostTagHistory::EvaluationLimits(), parameters.checkpoints);
 }
+
+TEST(PostTagSearcher, zeroTimeConstraint) {
+  PostTagSearcher searcher;
+  PostTagSearcher::EvaluationParameters parameters;
+  parameters.groupTimeConstraintNs = 0;
+  const auto result = searcher.evaluateRange(20, 123, 124, parameters);
+  ASSERT_EQ(result.size(), 3);
+  ASSERT_EQ(result[0].conclusionReason, PostTagSearcher::ConclusionReason::NotEvaluated);
+}
+
+TEST(PostTagSearcher, smallTimeConstraint) {
+  PostTagSearcher searcher;
+  PostTagSearcher::EvaluationParameters parameters;
+  parameters.groupTimeConstraintNs = 100000000;  // 0.1 seconds
+  // The following init takes ~4 seconds to terminate
+  const auto result = searcher.evaluateRange(64, 1473593303835332608, 1473593303835332609, parameters);
+  ASSERT_EQ(result.size(), 3);
+  ASSERT_EQ(result[0].conclusionReason, PostTagSearcher::ConclusionReason::TimeConstraintExceeded);
+}
 }  // namespace PostTagSystem


### PR DESCRIPTION
## Changes

* `PostTagSearcher` now correctly uses the time constraint parameter.
* `ConclusionReason` will either be `TimeConstraintExceeded` or `NotEvaluated` based on whether the time constraint was reached before or during the evaluation of a particular init.

## Comments

* Checkpoints #21 should be merged first.
* The time constraint will be exceeded slightly because results need to be collected.

## Examples

* The first result of the following concludes with reason `TimeConstraintExceeded`:
```c++
PostTagSearcher::EvaluationParameters parameters;
parameters.groupTimeConstraintNs = 100000000;  // 0.1 seconds
const auto result = PostTagSearcher().evaluateRange(
    64, 1473593303835332608, 1473593303835332609, parameters);
```
* The other two results are `NotEvaluated` for now, but that can change after parallelization is implemented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/22)
<!-- Reviewable:end -->
