### PR TITLE
Shared trie

### DIFF
--- a/libPostTagSystem/CheckpointsTrie.cpp
+++ b/libPostTagSystem/CheckpointsTrie.cpp
@@ -59,12 +59,12 @@ class CheckpointsTrie::Implementation {
     if (chunksBegin == chunksEnd) return false;  // it's a total match, don't insert a value
 
     if (*index >= 0) {
-      const auto nextChunkIt = trieNodes_[*index].find(*chunksBegin);
-      if (nextChunkIt == trieNodes_[*index].end()) {
+      const auto nextChunkIt = trieNodes_.at(*index).find(*chunksBegin);
+      if (nextChunkIt == trieNodes_.at(*index).end()) {
         reverseSuffixes_.push_back(std::vector<uint8_t>(std::reverse_iterator<ChunksIterator>(chunksEnd),
                                                         std::reverse_iterator<ChunksIterator>(chunksBegin) - 1));
         values_.push_back(value);
-        trieNodes_[*index].insert({*chunksBegin, fromReverseSuffixesIndex(reverseSuffixes_.size() - 1)});
+        trieNodes_.at(*index).insert({*chunksBegin, fromReverseSuffixesIndex(reverseSuffixes_.size() - 1)});
       } else {
         insertChunks(&nextChunkIt->second, chunksBegin + 1, chunksEnd, value);
       }
@@ -93,8 +93,8 @@ class CheckpointsTrie::Implementation {
     }
 
     if (index >= 0) {
-      const auto nextChunkIt = trieNodes_[index].find(*chunksBegin);
-      if (nextChunkIt == trieNodes_[index].end()) {
+      const auto nextChunkIt = trieNodes_.at(index).find(*chunksBegin);
+      if (nextChunkIt == trieNodes_.at(index).end()) {
         return std::nullopt;
       } else {
         return findValueInChunks(nextChunkIt->second, chunksBegin + 1, chunksEnd);
@@ -102,8 +102,8 @@ class CheckpointsTrie::Implementation {
     } else {
       const auto firstMismatch = std::mismatch(chunksBegin,
                                                chunksEnd,
-                                               reverseSuffixes_[toReverseSuffixesIndex(index)].rbegin(),
-                                               reverseSuffixes_[toReverseSuffixesIndex(index)].rend());
+                                               reverseSuffixes_.at(toReverseSuffixesIndex(index)).rbegin(),
+                                               reverseSuffixes_.at(toReverseSuffixesIndex(index)).rend());
       if (firstMismatch.first == chunksEnd) {
         return values_.at(fromReverseSuffixesIndex(index));
       } else {

--- a/libPostTagSystem/CheckpointsTrie.cpp
+++ b/libPostTagSystem/CheckpointsTrie.cpp
@@ -88,7 +88,6 @@ class CheckpointsTrie::Implementation {
 
   std::optional<int> findValueInChunks(int64_t index, ChunksIterator chunksBegin, ChunksIterator chunksEnd) const {
     if (chunksBegin == chunksEnd) {
-      if (index >= 0) throw std::runtime_error("trie keeps branching at the leaf, something is wrong");
       return values_.at(toReverseSuffixesIndex(index));
     }
 

--- a/libPostTagSystem/CheckpointsTrie.hpp
+++ b/libPostTagSystem/CheckpointsTrie.hpp
@@ -2,6 +2,7 @@
 #define LIBPOSTTAGSYSTEM_CHECKPOINTSTRIE_HPP_
 
 #include <memory>
+#include <optional>
 
 #include "ChunkedState.hpp"
 
@@ -9,8 +10,9 @@ namespace PostTagSystem {
 class CheckpointsTrie {
  public:
   CheckpointsTrie();
-  void insert(const ChunkedState& state);
-  bool contains(const ChunkedState& state) const;
+  // returns false if the value already exists, in which case the old key will remain
+  bool insert(const ChunkedState& key, int value);
+  std::optional<int> findValue(const ChunkedState& state) const;
 
  private:
   class Implementation;

--- a/libPostTagSystem/PostTagHistory.cpp
+++ b/libPostTagSystem/PostTagHistory.cpp
@@ -206,7 +206,7 @@ class PostTagHistory::Implementation {
         if (foundCheckpoint.value() == explicitCheckpoint) {
           *conclusionReason = ConclusionReason::ReachedExplicitCheckpoint;
           return eventCount;
-        } else if (foundCheckpoint.value() == index) {
+        } else if (foundCheckpoint.value() == static_cast<int>(index)) {
           *conclusionReason = ConclusionReason::ReachedAutomaticCheckpoint;
           return eventCount;
         } else {

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -15,6 +15,7 @@ class PostTagHistory {
     Terminated,
     ReachedExplicitCheckpoint,
     ReachedAutomaticCheckpoint,
+    ReachedPreviousInitCheckpoint,
     MaxEventCountExceeded,
     MaxTapeLengthExceeded,
     TimeConstraintExceeded,

--- a/libPostTagSystem/PostTagSearcher.cpp
+++ b/libPostTagSystem/PostTagSearcher.cpp
@@ -77,6 +77,10 @@ class PostTagSearcher::Implementation {
           result.conclusionReason = ConclusionReason::NotEvaluated;
           break;
 
+        case PostTagHistory::ConclusionReason::ReachedPreviousInitCheckpoint:
+          result.conclusionReason = ConclusionReason::MergedWithAnotherInit;
+          break;
+
         default:
           result.conclusionReason = ConclusionReason::InvalidInput;
       }

--- a/libPostTagSystem/PostTagSearcher.hpp
+++ b/libPostTagSystem/PostTagSearcher.hpp
@@ -17,11 +17,11 @@ class PostTagSearcher {
     Terminated,
     ReachedCycle,
     ReachedKnownCheckpoint,
-    MergedWithAnotherInit,
     MaxTapeLengthExceeded,
     MaxEventCountExceeded,
     TimeConstraintExceeded,
-    NotEvaluated
+    NotEvaluated,
+    MergedWithAnotherInit
   };
 
   struct EvaluationResult {

--- a/libPostTagSystem/PostTagSearcher.hpp
+++ b/libPostTagSystem/PostTagSearcher.hpp
@@ -17,6 +17,7 @@ class PostTagSearcher {
     Terminated,
     ReachedCycle,
     ReachedKnownCheckpoint,
+    MergedWithAnotherInit,
     MaxTapeLengthExceeded,
     MaxEventCountExceeded,
     TimeConstraintExceeded,

--- a/libPostTagSystem/test/CheckpointsTrie_test.cpp
+++ b/libPostTagSystem/test/CheckpointsTrie_test.cpp
@@ -10,14 +10,14 @@ void checkStateInsertion(const std::vector<ChunkedState>& insertedStates,
                          const std::vector<ChunkedState>& missingStates) {
   CheckpointsTrie trie;
   for (auto insertionIt = insertedStates.begin(); insertionIt != insertedStates.end(); ++insertionIt) {
-    trie.insert(*insertionIt);
+    trie.insert(*insertionIt, static_cast<int>(insertionIt - insertedStates.begin()));
     for (auto checkIt = insertedStates.begin(); checkIt != insertionIt + 1; ++checkIt) {
-      ASSERT_TRUE(trie.contains(*checkIt));
+      ASSERT_EQ(trie.findValue(*checkIt).value(), static_cast<int>(checkIt - insertedStates.begin()));
     }
   }
 
   for (const auto& state : missingStates) {
-    ASSERT_FALSE(trie.contains(state));
+    ASSERT_EQ(trie.findValue(state), std::nullopt);
   }
 }
 }  // namespace

--- a/libPostTagSystem/test/PostTagSearcher_test.cpp
+++ b/libPostTagSystem/test/PostTagSearcher_test.cpp
@@ -154,7 +154,7 @@ TEST(PostTagSearcher, smallTimeConstraint) {
   ASSERT_EQ(result[0].conclusionReason, PostTagSearcher::ConclusionReason::TimeConstraintExceeded);
 }
 
-TEST(PostTagSearcher, rangePerformance) {
+TEST(PostTagSearcher, DISABLED_rangePerformance) {
   // With separate tries: 0.36 GB, 1133 seconds
   // With shared trie: 1.1 GB of RAM, 93 seconds, 12x speedup, 3x more memory use
   PostTagSearcher().evaluateRange(30, 0, 1000000, PostTagSearcher::EvaluationParameters());

--- a/libPostTagSystem/test/PostTagSearcher_test.cpp
+++ b/libPostTagSystem/test/PostTagSearcher_test.cpp
@@ -151,6 +151,7 @@ TEST(PostTagSearcher, smallTimeConstraint) {
 }
 
 TEST(PostTagSearcher, rangePerformance) {
+  // Getting 45332 ms on 950557aae1eb3a9a799e12ac24ab49151be25c19 (master)
   PostTagSearcher().evaluateRange(30, 0, 100000, PostTagSearcher::EvaluationParameters());
 }
 }  // namespace PostTagSystem

--- a/libPostTagSystem/test/PostTagSearcher_test.cpp
+++ b/libPostTagSystem/test/PostTagSearcher_test.cpp
@@ -155,8 +155,8 @@ TEST(PostTagSearcher, smallTimeConstraint) {
 }
 
 TEST(PostTagSearcher, rangePerformance) {
-  // Getting 45332 ms on 950557aae1eb3a9a799e12ac24ab49151be25c19 (master)
-  // Getting  9916 ms on
-  PostTagSearcher().evaluateRange(30, 0, 100000, PostTagSearcher::EvaluationParameters());
+  // With separate tries: 0.36 GB, 1133 seconds
+  // With shared trie: 1.1 GB of RAM, 93 seconds, 12x speedup, 3x more memory use
+  PostTagSearcher().evaluateRange(30, 0, 1000000, PostTagSearcher::EvaluationParameters());
 }
 }  // namespace PostTagSystem

--- a/libPostTagSystem/test/PostTagSearcher_test.cpp
+++ b/libPostTagSystem/test/PostTagSearcher_test.cpp
@@ -149,4 +149,8 @@ TEST(PostTagSearcher, smallTimeConstraint) {
   ASSERT_EQ(result.size(), 3);
   ASSERT_EQ(result[0].conclusionReason, PostTagSearcher::ConclusionReason::TimeConstraintExceeded);
 }
+
+TEST(PostTagSearcher, rangePerformance) {
+  PostTagSearcher().evaluateRange(30, 0, 100000, PostTagSearcher::EvaluationParameters());
+}
 }  // namespace PostTagSystem

--- a/libPostTagSystem/test/PostTagSearcher_test.cpp
+++ b/libPostTagSystem/test/PostTagSearcher_test.cpp
@@ -35,20 +35,24 @@ void compareResults(const TagState& init,
 
   if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::InvalidInput) {
     ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::InvalidInput);
-  } else if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::Terminated) {
-    ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::Terminated);
-  } else if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::ReachedAutomaticCheckpoint) {
-    ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::ReachedCycle);
-  } else if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::ReachedExplicitCheckpoint) {
-    ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::ReachedKnownCheckpoint);
-  } else if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::MaxEventCountExceeded) {
-    ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::MaxEventCountExceeded);
+  } else if (result.conclusionReason != PostTagSearcher::ConclusionReason::MergedWithAnotherInit) {
+    if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::Terminated) {
+      ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::Terminated);
+    } else if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::ReachedAutomaticCheckpoint) {
+      ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::ReachedCycle);
+    } else if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::ReachedExplicitCheckpoint) {
+      ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::ReachedKnownCheckpoint);
+    } else if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::MaxEventCountExceeded) {
+      ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::MaxEventCountExceeded);
+    } else if (singleResult.conclusionReason == PostTagHistory::ConclusionReason::MaxTapeLengthExceeded) {
+      ASSERT_EQ(result.conclusionReason, PostTagSearcher::ConclusionReason::MaxTapeLengthExceeded);
+    }
+    ASSERT_EQ(result.finalState, singleResult.finalState);
+    ASSERT_EQ(result.eventCount, singleResult.eventCount);
+    ASSERT_EQ(result.maxTapeLength, singleResult.maxIntermediateTapeLength);
+    ASSERT_EQ(result.finalTapeLength, singleResult.finalState.tape.size());
   }
 
-  ASSERT_EQ(result.finalState, singleResult.finalState);
-  ASSERT_EQ(result.eventCount, singleResult.eventCount);
-  ASSERT_EQ(result.maxTapeLength, singleResult.maxIntermediateTapeLength);
-  ASSERT_EQ(result.finalTapeLength, singleResult.finalState.tape.size());
   ASSERT_EQ(result.initialState, init);
 }
 
@@ -152,6 +156,7 @@ TEST(PostTagSearcher, smallTimeConstraint) {
 
 TEST(PostTagSearcher, rangePerformance) {
   // Getting 45332 ms on 950557aae1eb3a9a799e12ac24ab49151be25c19 (master)
+  // Getting  9916 ms on
   PostTagSearcher().evaluateRange(30, 0, 100000, PostTagSearcher::EvaluationParameters());
 }
 }  // namespace PostTagSystem


### PR DESCRIPTION
## Changes

* Use shared trie for a range evaluation.
* This uses more memory but saves a lot of time because the same evaluation paths ("highways") don't need to be evaluated multiple times.
* To accommodate this case, `MergedWithAnotherInit` was added as a `ConclusionReason`.

## Comments

* There is currently no way to find out which other init this one was merged into. This potentially can be added, but it will require a change in the file format, so I did not add it now.
* A better approach might be to make this optimization invisible by automatically figuring out the values of all evaluation result components based on the information about the merge. I can work on this approach now, but I'm not sure I can finish it today (so it might have to wait until next week).

## Examples

* The difference in performance can be seen with a disabled test:
```c++
TEST(PostTagSearcher, DISABLED_rangePerformance) {
  // With separate tries: 0.36 GB, 1133 seconds
  // With shared trie: 1.1 GB of RAM, 93 seconds, 12x speedup, 3x more memory use
  PostTagSearcher().evaluateRange(30, 0, 1000000, PostTagSearcher::EvaluationParameters());
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/24)
<!-- Reviewable:end -->
