### PR TITLE
Excluding merged inits

### DIFF
--- a/libPostTagSystem/PostTagSearcher.cpp
+++ b/libPostTagSystem/PostTagSearcher.cpp
@@ -84,7 +84,8 @@ class PostTagSearcher::Implementation {
         default:
           result.conclusionReason = ConclusionReason::InvalidInput;
       }
-      if (result.conclusionReason != ConclusionReason::NotEvaluated || parameters.includeUnevaluatedStates) {
+      if ((result.conclusionReason != ConclusionReason::NotEvaluated || parameters.includeUnevaluatedStates) &&
+          (result.conclusionReason != ConclusionReason::MergedWithAnotherInit || parameters.includeMergedStates)) {
         results.push_back(result);
       }
     }

--- a/libPostTagSystem/PostTagSearcher.hpp
+++ b/libPostTagSystem/PostTagSearcher.hpp
@@ -52,6 +52,7 @@ class PostTagSearcher {
     int64_t groupTimeConstraintNs = std::numeric_limits<int64_t>::max();
     Checkpoints checkpoints = {};
     bool includeUnevaluatedStates = false;
+    bool includeMergedStates = false;
   };
 
   // The functions below use two tries. One for the input checkpoints which is shared among all of them. The other trie

--- a/libPostTagSystem/test/PostTagSearcher_test.cpp
+++ b/libPostTagSystem/test/PostTagSearcher_test.cpp
@@ -58,9 +58,12 @@ void compareResults(const TagState& init,
 
 TEST(PostTagSearcher, rangeOfTagStates) {
   PostTagSearcher searcher;
-  const auto result = searcher.evaluateRange({{0, 0, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1}, 0},
-                                             {{0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0}, 1},
-                                             PostTagSearcher::EvaluationParameters());
+
+  PostTagSearcher::EvaluationParameters evalParams;
+  evalParams.includeMergedStates = true;
+
+  const auto result = searcher.evaluateRange(
+      {{0, 0, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1}, 0}, {{0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0}, 1}, evalParams);
   ASSERT_EQ(result.size(), 106);
 
   compareResults(TagState({0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1}, 0), result[48]);


### PR DESCRIPTION
## Changes

* Add an EvaluationParameters option to include/exclude inits that merged with another init (set to exclude by default)

## Comments

* It turns out that in large scale computations ~99.9% of inits end up with this conclusion reason (which is good; it means the shared trie is very effective). These are of limited scientific interest, and discarding them massively reduces the size of output files.
* We may eventually want a generic mechanism for choosing the conclusion reasons to keep/discard. This could then be exposed on the command line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/25)
<!-- Reviewable:end -->
