### PR TITLE
Fix last tape

### DIFF
--- a/libPostTagSystem/PostTagSearcher.cpp
+++ b/libPostTagSystem/PostTagSearcher.cpp
@@ -11,7 +11,9 @@ class PostTagSearcher::Implementation {
                                               uint64_t tapeBegin,
                                               uint64_t tapeEnd,
                                               const EvaluationParameters& parameters) {
-    return evaluateRange(TagState(tapeLength, tapeBegin, 0), TagState(tapeLength, tapeEnd, 0), parameters);
+    return evaluateRange(TagState(tapeLength, tapeBegin, 0),
+                         TagState(tapeEnd == 1 << tapeLength ? tapeLength + 1 : tapeLength, tapeEnd, 0),
+                         parameters);
   }
 
   std::vector<EvaluationResult> evaluateRange(const TagState& begin,

--- a/libPostTagSystem/PostTagSearcher.cpp
+++ b/libPostTagSystem/PostTagSearcher.cpp
@@ -12,7 +12,7 @@ class PostTagSearcher::Implementation {
                                               uint64_t tapeEnd,
                                               const EvaluationParameters& parameters) {
     return evaluateRange(TagState(tapeLength, tapeBegin, 0),
-                         TagState(tapeEnd == 1 << tapeLength ? tapeLength + 1 : tapeLength, tapeEnd, 0),
+                         TagState(tapeEnd == 1u << tapeLength ? tapeLength + 1 : tapeLength, tapeEnd, 0),
                          parameters);
   }
 

--- a/libPostTagSystem/PostTagSearcher.cpp
+++ b/libPostTagSystem/PostTagSearcher.cpp
@@ -11,9 +11,10 @@ class PostTagSearcher::Implementation {
                                               uint64_t tapeBegin,
                                               uint64_t tapeEnd,
                                               const EvaluationParameters& parameters) {
-    return evaluateRange(TagState(tapeLength, tapeBegin, 0),
-                         TagState(tapeEnd == 1u << tapeLength ? tapeLength + 1 : tapeLength, tapeEnd, 0),
-                         parameters);
+    return evaluateRange(
+        TagState(tapeLength, tapeBegin, 0),
+        TagState(tapeEnd == static_cast<uint64_t>(1) << tapeLength ? tapeLength + 1 : tapeLength, tapeEnd, 0),
+        parameters);
   }
 
   std::vector<EvaluationResult> evaluateRange(const TagState& begin,

--- a/libPostTagSystem/test/PostTagSearcher_test.cpp
+++ b/libPostTagSystem/test/PostTagSearcher_test.cpp
@@ -157,6 +157,13 @@ TEST(PostTagSearcher, smallTimeConstraint) {
   ASSERT_EQ(result[0].conclusionReason, PostTagSearcher::ConclusionReason::TimeConstraintExceeded);
 }
 
+TEST(PostTagSearcher, lastTape) {
+  PostTagSearcher searcher;
+  PostTagSearcher::EvaluationParameters parameters;
+  const auto result = searcher.evaluateRange(10, 1023, 1024, parameters);
+  ASSERT_EQ(result.size(), 3);
+}
+
 TEST(PostTagSearcher, DISABLED_rangePerformance) {
   // With separate tries: 0.36 GB, 1133 seconds
   // With shared trie: 1.1 GB of RAM, 93 seconds, 12x speedup, 3x more memory use


### PR DESCRIPTION
## Changes

* Resolves #27.
* `uint64_t` `tapeEnd` was converted incorrectly to `TagState` `tapeEnd` due to `uint64_t` value exceeding `tapeLength` and becoming a zero as a result.
* Consequently, `evaluateRange` would never terminate as it will be generating new inits to infinity (the for-loop has a `state != end` stopping condition which is never reached).

## Comments

* The `tapeLength` is now increased in this situation.

## Examples

* The example from the issue now evaluates instantly as expected:

```console
$ ./wolfram-postproject --chase --initstart 1073741823 --initcount 1 --initsize 30
Maximum tape size: 1e+09
Maximum step count: 1e+10
Total evaluation time limit: unlimited
No crib file specified; not loading checkpoints

Evaluating 1 initial condition tapes, starting at 1073741823...
----------------
Evaluation finished with 3 results
Wrote results to './output.postresult'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/28)
<!-- Reviewable:end -->
