### PR TITLE
Fix macOS just-in-time compilation

### DIFF
--- a/DevUtils/BuildLibPostTagSystem.m
+++ b/DevUtils/BuildLibPostTagSystem.m
@@ -170,7 +170,7 @@ $compileOptions = Switch[$OperatingSystem,
   "Windows",
     {"/std:c++17", "/EHsc"},
   "MacOSX",
-    Join[{"-std=c++17"}, $warningsFlags, {"-mmacosx-version-min=10.12"}], (* for std::shared_mutex support *)
+    Join[{"-std=c++17"}, $warningsFlags, {"-mmacosx-version-min=10.14"}], (* for full support for optional *)
   "Unix",
     Join[{"-std=c++17"}, $warningsFlags]
 ];


### PR DESCRIPTION
## Changes

* Fixes just-in-time compilation which was broken on macOS.

## Examples

* Package is now compiled currently on `Get`:

```wl
Get["~/git/PostTagSystem/Kernel/init.m"];
In[] := GenerateTagSystemHistory[
  "Post", {0, {1, 1, 1, 1, 1, 1, 1, 1, 1, 1}}, 1000000, {"PowerOfTwoEventCounts"}]
Out[] = <|
  "EventCount" -> 4120, "MaxTapeLength" -> 69, "FinalState" -> {0, {0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0}}|>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/29)
<!-- Reviewable:end -->
