### PR TITLE
Checkpoints every event multiple

### DIFF
--- a/libPostTagSystem/PostTagHistory.cpp
+++ b/libPostTagSystem/PostTagHistory.cpp
@@ -184,7 +184,7 @@ class PostTagHistory::Implementation {
                            const EvaluationLimits& limits,
                            std::chrono::time_point<std::chrono::steady_clock> endClock,
                            CheckpointsTrie* checkpoints,
-                           const CheckpointSpecFlags& checkpointFlags) {
+                           const AutomaticCheckpointParameters& checkpointFlags) {
     if (std::chrono::steady_clock::now() > endClock) {
       *conclusionReason = ConclusionReason::NotEvaluated;
       return 0;
@@ -214,9 +214,8 @@ class PostTagHistory::Implementation {
           return eventCount;
         }
       }
-      constexpr uint64_t hundredBillion = 100000000000;
       if ((checkpointFlags.powerOfTwoEventCounts && !isPowerOfTwo(eventCount)) ||
-          (checkpointFlags.multipleOfHundredBillionEventCounts && (eventCount % hundredBillion == 0))) {
+          (checkpointFlags.eventCountsMultiple && (eventCount % checkpointFlags.eventCountsMultiple == 0))) {
         checkpoints->insert(*state, static_cast<int>(index));
       }
       evaluateOnce(evaluationTable, state);

--- a/libPostTagSystem/PostTagHistory.cpp
+++ b/libPostTagSystem/PostTagHistory.cpp
@@ -214,7 +214,9 @@ class PostTagHistory::Implementation {
           return eventCount;
         }
       }
-      if (checkpointFlags.powerOfTwoEventCounts && !isPowerOfTwo(eventCount)) {
+      constexpr uint64_t hundredBillion = 100000000000;
+      if ((checkpointFlags.powerOfTwoEventCounts && !isPowerOfTwo(eventCount)) ||
+          (checkpointFlags.multipleOfHundredBillionEventCounts && (eventCount % hundredBillion == 0))) {
         checkpoints->insert(*state, static_cast<int>(index));
       }
       evaluateOnce(evaluationTable, state);

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -33,6 +33,7 @@ class PostTagHistory {
 
   struct CheckpointSpecFlags {
     bool powerOfTwoEventCounts;
+    bool multipleOfHundredBillionEventCounts;
   };
 
   struct CheckpointSpec {

--- a/libPostTagSystem/PostTagHistory.hpp
+++ b/libPostTagSystem/PostTagHistory.hpp
@@ -31,14 +31,15 @@ class PostTagHistory {
 
   enum class NamedRule { Post = 0, Rule002211 = 1, Rule000010111 = 2 };
 
-  struct CheckpointSpecFlags {
+  static constexpr uint64_t eventCountsMultipleDisabled = 0;
+  struct AutomaticCheckpointParameters {
     bool powerOfTwoEventCounts;
-    bool multipleOfHundredBillionEventCounts;
+    uint64_t eventCountsMultiple;
   };
 
   struct CheckpointSpec {
     std::vector<TagState> states;
-    CheckpointSpecFlags flags;
+    AutomaticCheckpointParameters flags;
   };
 
   struct EvaluationLimits {

--- a/libPostTagSystem/PostTagSearcher.cpp
+++ b/libPostTagSystem/PostTagSearcher.cpp
@@ -47,7 +47,10 @@ class PostTagSearcher::Implementation {
     limits.maxTapeLength = parameters.maxTapeLength;
     limits.maxTimeNs = parameters.groupTimeConstraintNs;
     const auto singleInitResults =
-        evaluator.evaluate(PostTagHistory::NamedRule::Post, states, limits, {parameters.checkpoints, {true, true}});
+        evaluator.evaluate(PostTagHistory::NamedRule::Post,
+                           states,
+                           limits,
+                           {parameters.checkpoints, {true, parameters.automaticCheckpointsEveryEvents}});
     for (size_t initIndex = 0; initIndex < states.size(); ++initIndex) {
       EvaluationResult result;
       result.eventCount = singleInitResults[initIndex].eventCount;

--- a/libPostTagSystem/PostTagSearcher.cpp
+++ b/libPostTagSystem/PostTagSearcher.cpp
@@ -47,7 +47,7 @@ class PostTagSearcher::Implementation {
     limits.maxTapeLength = parameters.maxTapeLength;
     limits.maxTimeNs = parameters.groupTimeConstraintNs;
     const auto singleInitResults =
-        evaluator.evaluate(PostTagHistory::NamedRule::Post, states, limits, {parameters.checkpoints, {true}});
+        evaluator.evaluate(PostTagHistory::NamedRule::Post, states, limits, {parameters.checkpoints, {true, true}});
     for (size_t initIndex = 0; initIndex < states.size(); ++initIndex) {
       EvaluationResult result;
       result.eventCount = singleInitResults[initIndex].eventCount;

--- a/libPostTagSystem/PostTagSearcher.hpp
+++ b/libPostTagSystem/PostTagSearcher.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <vector>
 
+#include "PostTagHistory.hpp"
 #include "TagState.hpp"
 
 namespace PostTagSystem {
@@ -51,6 +52,7 @@ class PostTagSearcher {
     // values obtained so far. The remaining ones will be filled with zeros.
     int64_t groupTimeConstraintNs = std::numeric_limits<int64_t>::max();
     Checkpoints checkpoints = {};
+    uint64_t automaticCheckpointsEveryEvents = PostTagHistory::eventCountsMultipleDisabled;
     bool includeUnevaluatedStates = false;
     bool includeMergedStates = false;
   };

--- a/libPostTagSystem/WolframLanguageAPI.cpp
+++ b/libPostTagSystem/WolframLanguageAPI.cpp
@@ -119,7 +119,7 @@ std::vector<TagState> getStateVector(WolframLibraryData libData,
 PostTagHistory::CheckpointSpecFlags getCheckpointFlags(WolframLibraryData libData, const MTensor flags) {
   if (libData->MTensor_getFlattenedLength(flags) != 1) throw LIBRARY_FUNCTION_ERROR;
   const auto flagData = libData->MTensor_getIntegerData(flags);
-  return {static_cast<bool>(flagData[0])};
+  return {static_cast<bool>(flagData[0]), false};
 }
 
 int addEvolutionStartingFromState(WolframLibraryData libData, mint argc, MArgument* argv) {

--- a/libPostTagSystem/WolframLanguageAPI.cpp
+++ b/libPostTagSystem/WolframLanguageAPI.cpp
@@ -116,10 +116,10 @@ std::vector<TagState> getStateVector(WolframLibraryData libData,
   return result;
 }
 
-PostTagHistory::CheckpointSpecFlags getCheckpointFlags(WolframLibraryData libData, const MTensor flags) {
+PostTagHistory::AutomaticCheckpointParameters getCheckpointFlags(WolframLibraryData libData, const MTensor flags) {
   if (libData->MTensor_getFlattenedLength(flags) != 1) throw LIBRARY_FUNCTION_ERROR;
   const auto flagData = libData->MTensor_getIntegerData(flags);
-  return {static_cast<bool>(flagData[0]), false};
+  return {static_cast<bool>(flagData[0]), PostTagHistory::eventCountsMultipleDisabled};
 }
 
 int addEvolutionStartingFromState(WolframLibraryData libData, mint argc, MArgument* argv) {

--- a/libPostTagSystem/test/PostTagSystem_test.cpp
+++ b/libPostTagSystem/test/PostTagSystem_test.cpp
@@ -106,7 +106,6 @@ TEST(PostTagSystem, maxTapeLength) {
   ASSERT_EQ(lengthLimitResult.maxIntermediateTapeLength, eventLimitResult.maxIntermediateTapeLength);
 }
 
-// This test takes unreasonably long time, and is unlikely to break
 TEST(PostTagSystem, eventCountMultipleCheckpoints) {
   PostTagHistory evaluator;
   const TagState init(24, 9603135, 0);

--- a/libPostTagSystem/test/PostTagSystem_test.cpp
+++ b/libPostTagSystem/test/PostTagSystem_test.cpp
@@ -107,13 +107,13 @@ TEST(PostTagSystem, maxTapeLength) {
 }
 
 // This test takes unreasonably long time, and is unlikely to break
-TEST(PostTagSystem, DISABLED_multipleOfHundredBillionEventCounts) {
+TEST(PostTagSystem, eventCountMultipleCheckpoints) {
   PostTagHistory evaluator;
   const TagState init(24, 9603135, 0);
+  constexpr uint64_t million = 1000000;
   const auto result = PostTagHistory().evaluate(
-      PostTagHistory::NamedRule::Post, init, PostTagHistory::EvaluationLimits(), {{}, {false, true}});
-  constexpr uint64_t hundredBillion = 100000000000;
-  ASSERT_GT(result.eventCount, hundredBillion);
-  ASSERT_LT(result.eventCount, 2 * hundredBillion);
+      PostTagHistory::NamedRule::Post, init, PostTagHistory::EvaluationLimits(), {{}, {false, million}});
+  ASSERT_GT(result.eventCount, million);
+  ASSERT_LT(result.eventCount, 2 * million);
 }
 }  // namespace PostTagSystem

--- a/libPostTagSystem/test/PostTagSystem_test.cpp
+++ b/libPostTagSystem/test/PostTagSystem_test.cpp
@@ -105,4 +105,15 @@ TEST(PostTagSystem, maxTapeLength) {
   ASSERT_EQ(lengthLimitResult.finalState, eventLimitResult.finalState);
   ASSERT_EQ(lengthLimitResult.maxIntermediateTapeLength, eventLimitResult.maxIntermediateTapeLength);
 }
+
+// This test takes unreasonably long time, and is unlikely to break
+TEST(PostTagSystem, DISABLED_multipleOfHundredBillionEventCounts) {
+  PostTagHistory evaluator;
+  const TagState init(24, 9603135, 0);
+  const auto result = PostTagHistory().evaluate(
+      PostTagHistory::NamedRule::Post, init, PostTagHistory::EvaluationLimits(), {{}, {false, true}});
+  constexpr uint64_t hundredBillion = 100000000000;
+  ASSERT_GT(result.eventCount, hundredBillion);
+  ASSERT_LT(result.eventCount, 2 * hundredBillion);
+}
 }  // namespace PostTagSystem


### PR DESCRIPTION
## Changes

* Adds `AutomaticCheckpointParameters::eventCountsMultiple` which inserts checkpoints for every specified number of events.
* This is ***disabled*** by default in `PostTagSearcher`.
* 100B would insert a checkpoint every 5-10 minutes.

## Examples

* There is a new test:
```c++
PostTagHistory evaluator;
const TagState init(24, 9603135, 0);
constexpr uint64_t million = 1000000;
const auto result = PostTagHistory().evaluate(
    PostTagHistory::NamedRule::Post, init, PostTagHistory::EvaluationLimits(), {{}, {false, million}});
ASSERT_GT(result.eventCount, million);
ASSERT_LT(result.eventCount, 2 * million);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/posttagsystem/30)
<!-- Reviewable:end -->
